### PR TITLE
Only initialize less when installed

### DIFF
--- a/lib/twitter-bootstrap-rails/engine.rb
+++ b/lib/twitter-bootstrap-rails/engine.rb
@@ -2,16 +2,14 @@ module Twitter
   module Bootstrap
     module Rails
       class Engine < ::Rails::Engine
-
         config.after_initialize do |app|
-          twitter_bootstrap_less_files = config.root + 'vendor/stylesheets/bootstrap'
-          app.config.less.paths << twitter_bootstrap_less_files
-
-          puts app.config.less.paths.inspect
+          # Only run when less is installed
+          if app.config.try(:less)
+            twitter_bootstrap_less_files = config.root + 'vendor/stylesheets/bootstrap'
+            app.config.less.paths << twitter_bootstrap_less_files
+          end
         end
-
-	    end
+      end
     end
   end
 end
-


### PR DESCRIPTION
Hey,

I love this gem but I don't really use less. I don't think I'm alone :)

It was blowing up because I didn't have less installed. I changed engine.rb to only setup less when installed.

Cheers,
Brandon
