### PR TITLE
Added pills activation to bootstrap.js.coffee.

### DIFF
--- a/lib/generators/bootstrap/install/templates/bootstrap.coffee
+++ b/lib/generators/bootstrap/install/templates/bootstrap.coffee
@@ -3,6 +3,8 @@ $ ->
 $ ->
   $(".tabs").tabs()
 $ ->
+  $(".pills").pills()
+$ ->
   $("a[rel=twipsy]").twipsy live: true
 $ ->
   $("a[rel=popover]").popover offset: 10


### PR DESCRIPTION
Just a quick fix to add the "pills" activation to the default bootstrap Coffeescript file to mimic the existing activity of "tabs" activation.
