### PR TITLE
.alert class

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ twitter-bootstrap-rails generates a "bootstrap.js.coffee" file for you
 to /app/assets/javascripts/ folder.
 
     $ ->
-      $(".alert-message").alert()
+      $(".alert").alert()
     $ ->
       $(".tabs").button()
     $ ->

--- a/lib/generators/bootstrap/install/templates/bootstrap.coffee
+++ b/lib/generators/bootstrap/install/templates/bootstrap.coffee
@@ -1,5 +1,5 @@
 $ ->
-  $(".alert-message").alert()
+  $(".alert").alert()
 $ ->
   $(".tabs").button()
 $ ->


### PR DESCRIPTION
Hi

Bootstrap 2.0 renamed .alert-message to just .alert

This commit reflects that change in the documentation and installed bootstrap coffeescript file
