### PR TITLE
Ensuring top level namespace is used for Rails

### DIFF
--- a/lib/generators/bootstrap/install/install_generator.rb
+++ b/lib/generators/bootstrap/install/install_generator.rb
@@ -2,7 +2,7 @@ require 'rails/generators'
 
 module Bootstrap
   module Generators
-    class InstallGenerator < Rails::Generators::Base
+    class InstallGenerator < ::Rails::Generators::Base
       source_root File.expand_path("../templates", __FILE__)
       desc "This generator installs Twitter Bootstrap to Asset Pipeline"
 


### PR DESCRIPTION
This fixed https://github.com/seyhunak/twitter-bootstrap-rails/issues/65 for me.
