### PR TITLE
Adding "::" before to ensure correct top level namespace

### DIFF
--- a/lib/generators/bootstrap/install/install_generator.rb
+++ b/lib/generators/bootstrap/install/install_generator.rb
@@ -2,7 +2,7 @@ require 'rails/generators'
 
 module Bootstrap
   module Generators
-    class InstallGenerator < Rails::Generators::Base
+    class InstallGenerator < ::Rails::Generators::Base
       source_root File.expand_path("../templates", __FILE__)
       desc "This generator installs Twitter Bootstrap to Asset Pipeline"
 

--- a/lib/generators/bootstrap/layout/layout_generator.rb
+++ b/lib/generators/bootstrap/layout/layout_generator.rb
@@ -2,7 +2,7 @@ require 'rails/generators'
 
 module Bootstrap
   module Generators
-    class LayoutGenerator < Rails::Generators::Base
+    class LayoutGenerator < ::Rails::Generators::Base
       source_root File.expand_path("../templates", __FILE__)
       desc "This generator creates layout file with navigation."
       argument :layout_name, :type => :string, :default => "application"
@@ -12,7 +12,7 @@ module Bootstrap
       attr_reader :app_name, :container_class
 
       def generate_layout
-        app = Rails.application
+        app = ::Rails.application
         @app_name = app.class.to_s.split("::").first
         @container_class = layout_type == "fluid" ? "container-fluid" : "container"
         ext = app.config.generators.options[:rails][:template_engine] || :erb

--- a/lib/generators/bootstrap/themed/themed_generator.rb
+++ b/lib/generators/bootstrap/themed/themed_generator.rb
@@ -3,7 +3,7 @@ require 'rails/generators/generated_attribute'
 
 module Bootstrap
   module Generators
-    class ThemedGenerator < Rails::Generators::Base
+    class ThemedGenerator < ::Rails::Generators::Base
       source_root File.expand_path('../templates', __FILE__)
       argument :controller_path,    :type => :string
       argument :model_name,         :type => :string, :required => false
@@ -61,9 +61,9 @@ module Bootstrap
       def columns
         begin
           excluded_column_names = %w[id created_at updated_at]
-          Kernel.const_get(@model_name).columns.reject{|c| excluded_column_names.include?(c.name) }.collect{|c| Rails::Generators::GeneratedAttribute.new(c.name, c.type)}
+          Kernel.const_get(@model_name).columns.reject{|c| excluded_column_names.include?(c.name) }.collect{|c| ::Rails::Generators::GeneratedAttribute.new(c.name, c.type)}
         rescue NoMethodError
-          Kernel.const_get(@model_name).fields.collect{|c| c[1]}.reject{|c| excluded_column_names.include?(c.name) }.collect{|c| Rails::Generators::GeneratedAttribute.new(c.name, c.type.to_s)}
+          Kernel.const_get(@model_name).fields.collect{|c| c[1]}.reject{|c| excluded_column_names.include?(c.name) }.collect{|c| ::Rails::Generators::GeneratedAttribute.new(c.name, c.type.to_s)}
         end
       end
 
@@ -94,7 +94,7 @@ module Bootstrap
       end
 
       def ext
-        Rails.application.config.generators.options[:rails][:template_engine] || :erb
+        ::Rails.application.config.generators.options[:rails][:template_engine] || :erb
       end
 
     end


### PR DESCRIPTION
I edited all instances of Rails::\* to ::Rails::*.  I don't think this should cause any problems. I know that it fixed the problems I was encountering.

Hope this helps.
