### PR TITLE
Fix rel usage for tooltips

### DIFF
--- a/lib/generators/bootstrap/install/templates/bootstrap.coffee
+++ b/lib/generators/bootstrap/install/templates/bootstrap.coffee
@@ -5,8 +5,9 @@ jQuery ->
   $(".collapse").collapse()
   $(".dropdown-toggle").dropdown()
   $(".modal").modal()
-  $("a[rel]").popover()
+  $("a[rel=popover]").popover()
   $(".navbar").scrollspy()
   $(".tab").tab "show"
   $(".tooltip").tooltip()
-  $(".typeahead").typeahead() 
+  $(".typeahead").typeahead()
+  $("a[rel=tooltip]").tooltip()


### PR DESCRIPTION
Links that used Bootstraps recommended style of <a rel="tooltip" title="My Tooltip"></a> were ending up with a popover instead of a tooltip.
