### PR TITLE
Fixing of look and feel of the `.btn-navbar` button

### DIFF
--- a/lib/generators/bootstrap/layout/templates/layout.html.erb
+++ b/lib/generators/bootstrap/layout/templates/layout.html.erb
@@ -34,9 +34,9 @@
           <div class="container">
         <%- end -%>
           <a class="btn btn-navbar" data-target=".nav-collapse" data-toggle="collapse">
-            <span class="i-bar"></span>
-            <span class="i-bar"></span>
-            <span class="i-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
           </a>
           <a class="brand" href="#"><%= app_name %></a>
           <div class="<%= container_class %> nav-collapse">

--- a/lib/generators/bootstrap/layout/templates/layout.html.haml
+++ b/lib/generators/bootstrap/layout/templates/layout.html.haml
@@ -29,9 +29,9 @@
         .container
         <%- end -%>
           %a.btn.btn-navbar{"data-target" => ".nav-collapse", "data-toggle" => "collapse"}
-            %span.i-bar
-            %span.i-bar
-            %span.i-bar
+            %span.icon-bar
+            %span.icon-bar
+            %span.icon-bar
           %a.brand{:href => "#"}<%= app_name %>
           .<%=container_class%>.nav-collapse
             %ul.nav

--- a/lib/generators/bootstrap/layout/templates/layout.html.slim
+++ b/lib/generators/bootstrap/layout/templates/layout.html.slim
@@ -30,9 +30,9 @@ html lang="en"
         .container
         <%- end -%>
           a.btn.btn-navbar data-target=".nav-collapse" data-toggle="collapse"
-            span.i-bar
-            span.i-bar
-            span.i-bar
+            span.icon-bar
+            span.icon-bar
+            span.icon-bar
           a.brand href="#"<%= app_name %>
           .<%=container_class%>.nav-collapse
             ul.nav


### PR DESCRIPTION
There are no allusion about the `i-bar` CSS class in the vendor/toolkit/twitter/bootstrap/navbar.less folder.
The class name was renamed to `icon-bar`.

So these changes can fix look and feel of the `.btn-navbar` button.
