### PR TITLE
fixed indentation for some lines in erb templates

### DIFF
--- a/lib/generators/bootstrap/themed/templates/_form.html.erb
+++ b/lib/generators/bootstrap/themed/templates/_form.html.erb
@@ -1,12 +1,13 @@
 <% columns.each do |column| %>
 <div class="clearfix">
-   <%%= f.label :<%= column.name %>, t("activerecord.attributes.<%= model_name.underscore %>.<%= column.name %>", :default => "<%= column.name.humanize %>"), :class => :label %>
+  <%%= f.label :<%= column.name %>, t("activerecord.attributes.<%= model_name.underscore %>.<%= column.name %>", :default => "<%= column.name.humanize %>"), :class => :label %>
   <div class="input">
     <%%= f.<%= column.field_type %> :<%= column.name %>, :class => '<%= column.field_type %>' %>
   </div>
 </div>
 <%- end -%>
+
 <div class="form-actions">
-  <button class="btn primary" type="submit">Save</button> or
-	<%%= link_to "Cancel", <%= controller_routing_path %>_path %>
+  <%%= button nil, :class => "btn btn-primary" %>
+  <%%= link_to "Cancel", <%= controller_routing_path %>_path %>, :class => 'btn' %>
 </div>

--- a/lib/generators/bootstrap/themed/templates/edit.html.erb
+++ b/lib/generators/bootstrap/themed/templates/edit.html.erb
@@ -1,4 +1,3 @@
-<%%= form_for @<%= model_name.underscore  %>, :url => <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :html => { :class => "edit_<%= model_name.underscore  %>", :id => "edit_<%= model_name.underscore %>" } do |f| -%>
-  <input name="_method" type="hidden" value="put" />
+<%%= form_for @<%= model_name.underscore  %>, :url => <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :html => { :method => "put", :class => "edit_<%= model_name.underscore  %>", :id => "edit_<%= model_name.underscore %>" } do |f| -%>
   <%%= render :partial => "form", :locals => {:f => f} %>
 <%% end -%>

--- a/lib/generators/bootstrap/themed/templates/index.html.erb
+++ b/lib/generators/bootstrap/themed/templates/index.html.erb
@@ -1,34 +1,33 @@
 <h1><%= resource_name.titleize %>s</h1>
 <table class="table table-striped">
- <thead>
-  <tr>
-    <th>ID</th>
-    <% unless columns.empty? -%>
-    <th>
-      <%%= t("activerecord.attributes.<%= singular_controller_routing_path %>.<%= columns.first.name %>", :default => t("activerecord.labels.<%= columns.first.name %>", :default => "<%= columns.first.name.capitalize %>")) %>
-    </th>
-    <% end -%>
-    <th>Created at</th>
-    <th>Actions</th>
-  </tr>
+  <thead>
+    <tr>
+      <th>ID</th>
+      <%- unless columns.empty? -%>
+      <th>
+        <%%= t("activerecord.attributes.<%= singular_controller_routing_path %>.<%= columns.first.name %>", :default => t("activerecord.labels.<%= columns.first.name %>", :default => "<%= columns.first.name.capitalize %>")) %>
+      </th>
+      <%- end -%>
+      <th>Created at</th>
+      <th>Actions</th>
+    </tr>
   </thead>
   <tbody>
-  <%% @<%= plural_resource_name %>.each do |<%= resource_name %>| -%>
-   <tr>
-    <td><%%= <%= resource_name %>.id %></td>
-    <% unless columns.empty? -%>
-    <td><%%= link_to <%= resource_name %>.<%= columns.first.name %>, <%= singular_controller_routing_path %>_path(<%= resource_name %>) %>
-    </td>
-    <% end -%>
-    <td><%%= <%= resource_name %>.created_at %></td>
-    <td>
-      <%%= link_to "Show", <%= singular_controller_routing_path %>_path(<%= resource_name %>) %>
-      <%%= link_to "Edit", edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>) %>
-      <%%= link_to "Destroy", <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :confirm => "#{t("web-app-theme.confirm", :default => "Are you sure?")}" %>
-    </td>
-    </tr>
+    <%% @<%= plural_resource_name %>.each do |<%= resource_name %>| -%>
+      <tr>
+        <td><%%= <%= resource_name %>.id %></td>
+        <%- unless columns.empty? -%>
+        <td><%%= link_to <%= resource_name %>.<%= columns.first.name %>, <%= singular_controller_routing_path %>_path(<%= resource_name %>) %></td>
+        <%- end -%>
+        <td><%%= <%= resource_name %>.created_at %></td>
+        <td>
+          <%%= link_to "Show", <%= singular_controller_routing_path %>_path(<%= resource_name %>) %>
+          <%%= link_to "Edit", edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>) %>
+          <%%= link_to "Destroy", <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :confirm => "#{t("web-app-theme.confirm", :default => "Are you sure?")}" %>
+        </td>
+      </tr>
     <%% end -%>
-   </tbody>
+  </tbody>
 </table>
 
 <%%= link_to "New", new_<%= singular_controller_routing_path %>_path, :class => 'btn btn-primary' %>

--- a/lib/generators/bootstrap/themed/templates/show.html.erb
+++ b/lib/generators/bootstrap/themed/templates/show.html.erb
@@ -4,7 +4,7 @@
 <%- end -%>
 
 <div class="form-actions">
-<%%= link_to "Back", <%= controller_routing_path %>_path, :class => 'btn'  %>
-<%%= link_to "Edit", edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), :class => 'btn' %>
-<%%= link_to "Delete", <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :method => "delete", :confirm => "#{t("web-app-theme.confirm", :default => "Are you sure?")}", :class => 'btn' %>
+  <%%= link_to "Back", <%= controller_routing_path %>_path, :class => 'btn'  %>
+  <%%= link_to "Edit", edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), :class => 'btn' %>
+  <%%= link_to "Delete", <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :method => "delete", :confirm => "#{t("web-app-theme.confirm", :default => "Are you sure?")}", :class => 'btn' %>
 </div>


### PR DESCRIPTION
Fixed indentation for some lines in erb templates. Now the generated templates looks right.
