### PR TITLE
Clean up generator's ERB theme

### DIFF
--- a/lib/generators/bootstrap/themed/templates/_form.html.erb
+++ b/lib/generators/bootstrap/themed/templates/_form.html.erb
@@ -1,13 +1,19 @@
-<% columns.each do |column| %>
-<div class="clearfix">
-  <%%= f.label :<%= column.name %>, t("activerecord.attributes.<%= model_name.underscore %>.<%= column.name %>", :default => "<%= column.name.humanize %>"), :class => :label %>
-  <div class="input">
-    <%%= f.<%= column.field_type %> :<%= column.name %>, :class => '<%= column.field_type %>' %>
-  </div>
-</div>
-<%- end -%>
+<%%= form_for @<%= model_name.underscore  %>, :html => { :class => 'form-horizontal' } do |f| %>
+  <fieldset>
+    <legend><%%= controller.action_name.capitalize %> <%= model_name.titleize %></legend>
 
-<div class="form-actions">
-  <%%= button nil, :class => "btn btn-primary" %>
-  <%%= link_to "Cancel", <%= controller_routing_path %>_path %>, :class => 'btn' %>
-</div>
+    <%- columns.each do |column| -%>
+    <div class="control-group">
+      <%%= f.label :<%= column.name %>, :class => 'control-label' %>
+      <div class="controls">
+        <%%= f.<%= column.field_type %> :<%= column.name %>, :class => '<%= column.field_type %>' %>
+      </div>
+    </div>
+
+    <%- end -%>
+    <div class="form-actions">
+      <%%= f.submit nil, :class => 'btn btn-primary' %>
+      <%%= link_to 'Cancel', <%= controller_routing_path %>_path, :class => 'btn' %>
+    </div>
+  </fieldset>
+<%% end %>

--- a/lib/generators/bootstrap/themed/templates/edit.html.erb
+++ b/lib/generators/bootstrap/themed/templates/edit.html.erb
@@ -1,3 +1,1 @@
-<%%= form_for @<%= model_name.underscore  %>, :url => <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :html => { :method => "put", :class => "edit_<%= model_name.underscore  %>", :id => "edit_<%= model_name.underscore %>" } do |f| -%>
-  <%%= render :partial => "form", :locals => {:f => f} %>
-<%% end -%>
+<%%= render :partial => 'form' %>

--- a/lib/generators/bootstrap/themed/templates/index.html.erb
+++ b/lib/generators/bootstrap/themed/templates/index.html.erb
@@ -4,16 +4,14 @@
     <tr>
       <th>ID</th>
       <%- unless columns.empty? -%>
-      <th>
-        <%%= t("activerecord.attributes.<%= singular_controller_routing_path %>.<%= columns.first.name %>", :default => t("activerecord.labels.<%= columns.first.name %>", :default => "<%= columns.first.name.capitalize %>")) %>
-      </th>
+      <th><%= columns.first.name.humanize %></th>
       <%- end -%>
       <th>Created at</th>
       <th>Actions</th>
     </tr>
   </thead>
   <tbody>
-    <%% @<%= plural_resource_name %>.each do |<%= resource_name %>| -%>
+    <%% @<%= plural_resource_name %>.each do |<%= resource_name %>| %>
       <tr>
         <td><%%= <%= resource_name %>.id %></td>
         <%- unless columns.empty? -%>
@@ -21,13 +19,12 @@
         <%- end -%>
         <td><%%= <%= resource_name %>.created_at %></td>
         <td>
-          <%%= link_to "Show", <%= singular_controller_routing_path %>_path(<%= resource_name %>) %>
-          <%%= link_to "Edit", edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>) %>
-          <%%= link_to "Destroy", <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :confirm => "#{t("web-app-theme.confirm", :default => "Are you sure?")}" %>
+          <%%= link_to 'Edit', edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-mini' %>
+          <%%= link_to 'Destroy', <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :confirm => 'Are you sure?', :class => 'btn btn-mini btn-danger' %>
         </td>
       </tr>
-    <%% end -%>
+    <%% end %>
   </tbody>
 </table>
 
-<%%= link_to "New", new_<%= singular_controller_routing_path %>_path, :class => 'btn btn-primary' %>
+<%%= link_to 'New', new_<%= singular_controller_routing_path %>_path, :class => 'btn btn-primary' %>

--- a/lib/generators/bootstrap/themed/templates/new.html.erb
+++ b/lib/generators/bootstrap/themed/templates/new.html.erb
@@ -1,3 +1,1 @@
-<%%= form_for @<%= model_name.underscore  %>, :url => <%= controller_routing_path %>_path, :html => { :class => :form } do |f| -%>
-  <%%= render :partial => "form", :locals => {:f => f} %>
-<%% end -%>
+<%%= render :partial => 'form' %>

--- a/lib/generators/bootstrap/themed/templates/show.html.erb
+++ b/lib/generators/bootstrap/themed/templates/show.html.erb
@@ -1,10 +1,14 @@
-<% columns.each do |column| %>
-<label class="label"><%%= t("activerecord.attributes.<%= singular_controller_routing_path %>.<%= column.name %>", :default => t("activerecord.labels.<%= column.name %>", :default => "<%= column.name.humanize %>")) %>:</label>
-<p><%%= @<%= resource_name %>.<%= column.name %> %></p>
-<%- end -%>
+<h1><%= model_name.titleize %></h1>
 
+<%- columns.each do |column| -%>
+<p>
+  <b><%= column.name.humanize %></b><br>
+  <%%= @<%= resource_name %>.<%= column.name %> %>
+</p>
+
+<%- end -%>
 <div class="form-actions">
-  <%%= link_to "Back", <%= controller_routing_path %>_path, :class => 'btn'  %>
-  <%%= link_to "Edit", edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), :class => 'btn' %>
-  <%%= link_to "Delete", <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :method => "delete", :confirm => "#{t("web-app-theme.confirm", :default => "Are you sure?")}", :class => 'btn' %>
+  <%%= link_to 'Back', <%= controller_routing_path %>_path, :class => 'btn'  %>
+  <%%= link_to 'Edit', edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), :class => 'btn' %>
+  <%%= link_to 'Delete', <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :method => 'delete', :confirm => 'Are you sure?', :class => 'btn btn-danger' %>
 </div>


### PR DESCRIPTION
Makes the theme generator output cleaner and following 2.0's style.

I haven't done Slim or HAML yet, just seeing if this is okay first.

Output code:

https://gist.github.com/1883522

Screen caps:

`index`
![index](http://i.minus.com/iYMJNvGPffUJz.png)

`show`
![index](http://i.minus.com/ib03yVZnJRB0ih.png)

`edit`
![index](http://i.minus.com/iuHLOSBiWwI2a.png)

`new`
![index](http://i.minus.com/izQj7mL6ApvQU.png)
