### PR TITLE
Small HAML bugfix

### DIFF
--- a/lib/generators/bootstrap/themed/templates/show.html.haml
+++ b/lib/generators/bootstrap/themed/templates/show.html.haml
@@ -6,4 +6,4 @@
 .form-actions
   = link_to "Back", <%= controller_routing_path %>_path, :class => 'btn'
   = link_to "Edit", edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), :class => 'btn'
-  = link_to "Delete", <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :method => "delete", :confirm => "#{t("web-app-theme.confirm", :default => "Are you sure?")}", :class => 'btn'
+  = link_to "Delete", <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :method => "delete", :confirm => "#{t("web-app-theme.confirm", :default => "Are you sure?")}", :class => 'btn btn-danger'


### PR DESCRIPTION
Related to issue #130, and commit cac6ac5e0f52b88aab5e9bcfdffe5cae87ab3085

The Delete button on the show template did not get the `btn-danger` class.
