### PR TITLE
Add namespacing support to themed generator

### DIFF
--- a/lib/generators/bootstrap/themed/themed_generator.rb
+++ b/lib/generators/bootstrap/themed/themed_generator.rb
@@ -24,7 +24,7 @@ module Bootstrap
       def initialize_views_variables
         @base_name, @controller_class_path, @controller_file_path, @controller_class_nesting, @controller_class_nesting_depth = extract_modules(controller_path)
         @controller_routing_path = @controller_file_path.gsub(/\//, '_')
-        @model_name = @base_name.singularize unless @model_name
+        @model_name = @controller_class_nesting + "::#{@base_name.singularize}" unless @model_name
         @model_name = @model_name.camelize
       end
 


### PR DESCRIPTION
Hi

This pull request is related to #137. I changed the way @model_name is defined to include the nesting string. Like this, the themed generator works for me on namespaced models.

Could add some specs if you care.
