### PR TITLE
1.8 compatibility issue for breadcrumb

### DIFF
--- a/app/helpers/twitter_breadcrumbs_helper.rb
+++ b/app/helpers/twitter_breadcrumbs_helper.rb
@@ -1,5 +1,5 @@
 module TwitterBreadcrumbsHelper
   def render_breadcrumbs(divider = '/')
-    render partial => 'twitter-bootstrap/breadcrumbs', locals => {divider => divider}
+    render :partial => 'twitter-bootstrap/breadcrumbs', :locals => {:divider => divider}
   end
 end

--- a/lib/twitter/bootstrap/rails/twitter-bootstrap-breadcrumbs.rb
+++ b/lib/twitter/bootstrap/rails/twitter-bootstrap-breadcrumbs.rb
@@ -18,7 +18,7 @@ module Twitter
       def add_breadcrumb name, url = ''
         @breadcrumbs ||= []
         url = eval(url) if url =~ /_path|_url|@/
-          @breadcrumbs << {name => name, url => url}
+          @breadcrumbs << {:name => name, :url => url}
       end
     end
   end


### PR DESCRIPTION
Fixing hash notation for breadcrumb helper and add_breadcrumb function
