### PR TITLE
Camelize model name before adding scope

### DIFF
--- a/lib/generators/bootstrap/themed/themed_generator.rb
+++ b/lib/generators/bootstrap/themed/themed_generator.rb
@@ -24,7 +24,7 @@ module Bootstrap
       def initialize_views_variables
         @base_name, @controller_class_path, @controller_file_path, @controller_class_nesting, @controller_class_nesting_depth = extract_modules(controller_path)
         @controller_routing_path = @controller_file_path.gsub(/\//, '_')
-        @model_name = @controller_class_nesting + "::#{@base_name.singularize}" unless @model_name
+        @model_name = @controller_class_nesting + "::#{@base_name.singularize.camelize}" unless @model_name
         @model_name = @model_name.camelize
       end
 


### PR DESCRIPTION
If model name is left out when invoking the bootstrap:themed generator it doesn't get camelized since '::' is prepended to the model name.

This PR camelize the model name before adding '::'.

From Issue #157
