### PR TITLE
Documentation: Change case of resource for bootstrap:themed

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Example:
 
     rails g scaffold post title:string description:text
     rake db:migrate
-    rails g bootstrap:themed posts
+    rails g bootstrap:themed Posts
 
 
 


### PR DESCRIPTION
The documentation seems to be out of sync with what's required for bootstrap:themed.

The only change is the case of posts => Posts
