### PR TITLE
Modified Themed HAML templates to reflect ERB

### DIFF
--- a/lib/generators/bootstrap/themed/templates/_form.html.haml
+++ b/lib/generators/bootstrap/themed/templates/_form.html.haml
@@ -1,13 +1,14 @@
-%fieldset
-  %legend
-    = controller.action_name.capitalize
-    <%= model_name.titleize %>
-  <%- columns.each do |column| -%>
-  .control-group
-    = f.label :<%= column.name %>, :class => 'control-label'
-    .controls
-      = f.<%= column.field_type %> :<%= column.name %>, :class => '<%= column.field_type %>'
-  <%- end -%>
-  .form-actions
-    = f.submit nil, :class => 'btn btn-primary'
-    = link_to "Cancel", <%= controller_routing_path %>_path, :class => 'btn'
+= form_for @<%= resource_name %>, :html => { :class => 'form-horizontal' } do |f|
+  %fieldset
+    %legend
+      = controller.action_name.capitalize
+      <%= model_name.titleize %>
+    <%- columns.each do |column| -%>
+    .control-group
+      = f.label :<%= column.name %>, :class => 'control-label'
+      .controls
+        = f.<%= column.field_type %> :<%= column.name %>, :class => '<%= column.field_type %>'
+    <%- end -%>
+    .form-actions
+      = f.submit nil, :class => 'btn btn-primary'
+      = link_to "Cancel", <%= controller_routing_path %>_path, :class => 'btn'

--- a/lib/generators/bootstrap/themed/templates/edit.html.haml
+++ b/lib/generators/bootstrap/themed/templates/edit.html.haml
@@ -1,2 +1,1 @@
-= form_for @<%= resource_name %>, :html => { :class => "edit_<%= resource_name %> form-horizontal", :id => "edit_<%= resource_name %>" } do |f|
-  = render :partial => "form", :locals => {:f => f}
+= render :partial => "form"

--- a/lib/generators/bootstrap/themed/templates/index.html.haml
+++ b/lib/generators/bootstrap/themed/templates/index.html.haml
@@ -1,5 +1,5 @@
 %h1 <%= resource_name.titleize %>s
-%table{:class => "table table-striped"}
+%table.table.table-striped
   %thead
     %tr
       %th ID

--- a/lib/generators/bootstrap/themed/templates/new.html.haml
+++ b/lib/generators/bootstrap/themed/templates/new.html.haml
@@ -1,2 +1,1 @@
-= form_for @<%= resource_name %>, :html => { :class => 'form-horizontal' } do |f|
-  = render :partial => "form", :locals => {:f => f}
+= render :partial => "form"

--- a/lib/generators/bootstrap/themed/templates/show.html.haml
+++ b/lib/generators/bootstrap/themed/templates/show.html.haml
@@ -1,6 +1,8 @@
 <%- columns.each do |column| -%>
-%label{:class => "label"}= t("activerecord.attributes.<%= singular_controller_routing_path %>.<%= column.name %>", :default => t("activerecord.labels.<%= column.name %>", :default => "<%= column.name.humanize %>")) + ":"
-%p= @<%= resource_name %>.<%= column.name %>
+%p
+  %strong= t("activerecord.attributes.<%= singular_controller_routing_path %>.<%= column.name %>", :default => t("activerecord.labels.<%= column.name %>", :default => "<%= column.name.humanize %>")) + ":"
+  %br
+  = @<%= resource_name %>.<%= column.name %>
 <%- end -%>
 
 .form-actions


### PR DESCRIPTION
Made a few changes to the haml themed templates. The show page looked really funny using the `label` tag, so I made it look just like the erb template you had. 

Moved the `form_for` into the `_form.html.haml` as it is in the ERB. This removes the duplicate code that was in the edit/new HAML views.

Thanks,
Andrew Davis
