### PR TITLE
Add a helper for twitter-style alert banners

### DIFF
--- a/app/helpers/flash_block_helper.rb
+++ b/app/helpers/flash_block_helper.rb
@@ -1,0 +1,17 @@
+module FlashBlockHelper
+  def flash_block
+    output = ''
+    flash.each do |type, message|
+      output += flash_container(type, message)
+    end
+
+    raw(output)
+  end
+
+  def flash_container(type, message)
+    raw(content_tag(:div, :class => "alert alert-#{type}") do
+      content_tag(:a, raw("&times;"),:class => 'close', :data => {:dismiss => 'alert'}) +
+      message
+    end)
+  end
+end


### PR DESCRIPTION
Added a `flash_block` helper that will display the alert messages in a twitter style alert window. To use just put `<%= flash_block %>` wherever you want the flash messages to appear
