### PR TITLE
Added spaces around generated text between the buttons on forms

### DIFF
--- a/lib/generators/bootstrap/themed/templates/_form.html.slim
+++ b/lib/generators/bootstrap/themed/templates/_form.html.slim
@@ -7,5 +7,5 @@
 
 .form-actions
   button class="btn primary" type="submit" Save
-  | or
+  |  or 
   = link_to "Cancel", <%= controller_routing_path %>_path


### PR DESCRIPTION
When running the "themed" generator for a controller using Slim, there is no spacing around the "or" between the "Save" and "Cancel" links on forms.

This change adds a single space either side of the "or" to improve the look and feel of the form.
