### PR TITLE
Use identical markup for all templating systems

### DIFF
--- a/lib/generators/bootstrap/layout/templates/layout.html.erb
+++ b/lib/generators/bootstrap/layout/templates/layout.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><%= app_name %></title>
+    <title><%%= content_for?(:title) ? yield(:title) : "<%= app_name %>" %></title>
     <%%= csrf_meta_tags %>
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
@@ -11,10 +11,8 @@
       <script src="http://html5shim.googlecode.com/svn/trunk/html5.js" type="text/javascript"></script>
     <![endif]-->
 
-    <!-- Le styles -->
     <%%= stylesheet_link_tag "application", :media => "all" %>
 
-    <!-- Le fav and touch icons -->
     <link href="images/favicon.ico" rel="shortcut icon">
     <link href="images/apple-touch-icon.png" rel="apple-touch-icon">
     <link href="images/apple-touch-icon-72x72.png" rel="apple-touch-icon" sizes="72x72">
@@ -37,9 +35,9 @@
           <a class="brand" href="#"><%= app_name %></a>
           <div class="<%= container_class %> nav-collapse">
             <ul class="nav">
-              <%- (1..3).each do |i| -%>
-                <li><%%= link_to "Link<%= i %>", "/path<%= i %>"  %></li>
-              <%- end -%>
+              <li><%%= link_to "Link1", "/path1"  %></li>
+              <li><%%= link_to "Link2", "/path2"  %></li>
+              <li><%%= link_to "Link3", "/path3"  %></li>
             </ul>
           </div><!--/.nav-collapse -->
         </div>
@@ -53,9 +51,9 @@
           <div class="well sidebar-nav">
             <ul class="nav nav-list">
               <li class="nav-header">Sidebar</li>
-              <%- (1..3).each do |i| -%>
-                <li><%%= link_to "Link<%= i %>", "/path<%= i %>"  %></li>
-              <%- end -%>
+              <li><%%= link_to "Link1", "/path1"  %></li>
+              <li><%%= link_to "Link2", "/path2"  %></li>
+              <li><%%= link_to "Link3", "/path3"  %></li>
             </ul>
           </div><!--/.well -->
         </div><!--/span-->
@@ -74,9 +72,9 @@
                 <h3>Sidebar</h3>
                 <ul class="nav nav-list">
                   <li class="nav-header">Sidebar</li>
-                  <%- (1..3).each do |i| -%>
-                    <li><%%= link_to "Link<%= i %>", "/path<%= i %>"  %></li>
-                  <%- end -%>
+                  <li><%%= link_to "Link1", "/path1"  %></li>
+                  <li><%%= link_to "Link2", "/path2"  %></li>
+                  <li><%%= link_to "Link3", "/path3"  %></li>
                 </ul>
               </div><!--/.well -->
             </div><!--/span-->
@@ -90,7 +88,7 @@
 
     </div> <!-- /container -->
 
-    <!-- Le javascript
+    <!-- Javascripts
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
     <%%= javascript_include_tag "application" %>

--- a/lib/generators/bootstrap/layout/templates/layout.html.haml
+++ b/lib/generators/bootstrap/layout/templates/layout.html.haml
@@ -2,20 +2,18 @@
 %html(lang="en")
   %head
     %meta(charset="utf-8")
+    %meta(name="viewport" content="width=device-width, initial-scale=1.0")
     %title= content_for?(:title) ? yield(:title) : "<%= app_name %>"
     = csrf_meta_tags
     / Le HTML5 shim, for IE6-8 support of HTML elements
     /[if lt IE 9]
       = javascript_include_tag "http://html5shim.googlecode.com/svn/trunk/html5.js"
-    / Le styles
     = stylesheet_link_tag "application", :media => "all"
-    / Le fav and touch icons
     %link(href="images/favicon.ico" rel="shortcut icon")
     %link(href="images/apple-touch-icon.png" rel="apple-touch-icon")
     %link(href="images/apple-touch-icon-72x72.png" rel="apple-touch-icon" sizes="72x72")
     %link(href="images/apple-touch-icon-114x114.png" rel="apple-touch-icon" sizes="114x114")
-  
-  
+
   %body
     .navbar.navbar-fixed-top
       .navbar-inner
@@ -65,7 +63,7 @@
       %footer
         %p &copy; Company 2012
     /
-      Le javascript
+      Javascripts
       \==================================================
     / Placed at the end of the document so the pages load faster
     = javascript_include_tag "application"

--- a/lib/generators/bootstrap/layout/templates/layout.html.slim
+++ b/lib/generators/bootstrap/layout/templates/layout.html.slim
@@ -2,20 +2,18 @@ doctype html
 html lang="en"
   head
     meta charset="utf-8"
+    meta name="viewport" content="width=device-width, initial-scale=1.0"
     title= content_for?(:title) ? yield(:title) : "<%= app_name %>"
     = csrf_meta_tags
 
     /! Le HTML5 shim, for IE6-8 support of HTML elements
     /[if lt IE 9]
       = javascript_include_tag "http://html5shim.googlecode.com/svn/trunk/html5.js"
-    /! Le styles
-      = stylesheet_link_tag "application", :media => "all"
-    / Le fav and touch icons
+    = stylesheet_link_tag "application", :media => "all"
     link href="images/favicon.ico" rel="shortcut icon"
     link href="images/apple-touch-icon.png" rel="apple-touch-icon"
     link href="images/apple-touch-icon-72x72.png" rel="apple-touch-icon" sizes="72x72"
     link href="images/apple-touch-icon-114x114.png" rel="apple-touch-icon" sizes="114x114"
-
 
   body
     .navbar.navbar-fixed-top
@@ -66,7 +64,7 @@ html lang="en"
       footer
         p &copy; Company 2012
     /!
-      Le javascript
+      Javascripts
       \==================================================
     /! Placed at the end of the document so the pages load faster
     = javascript_include_tag "application"

--- a/lib/generators/bootstrap/themed/templates/_form.html.erb
+++ b/lib/generators/bootstrap/themed/templates/_form.html.erb
@@ -1,6 +1,6 @@
 <%%= form_for @<%= resource_name %>, :html => { :class => 'form-horizontal' } do |f| %>
   <fieldset>
-    <legend><%%= controller.action_name.capitalize %> <%= model_name.titleize %></legend>
+    <legend><%%= controller.action_name.capitalize %> <%= resource_name.titleize %></legend>
 
     <%- columns.each do |column| -%>
     <div class="control-group">

--- a/lib/generators/bootstrap/themed/templates/_form.html.haml
+++ b/lib/generators/bootstrap/themed/templates/_form.html.haml
@@ -2,7 +2,7 @@
   %fieldset
     %legend
       = controller.action_name.capitalize
-      <%= model_name.titleize %>
+      <%= resource_name.titleize %>
     <%- columns.each do |column| -%>
     .control-group
       = f.label :<%= column.name %>, :class => 'control-label'

--- a/lib/generators/bootstrap/themed/templates/_form.html.slim
+++ b/lib/generators/bootstrap/themed/templates/_form.html.slim
@@ -1,11 +1,15 @@
-<%- columns.each do |column| -%>
-.clearfix
-  = f.label :<%= column.name %>, t("activerecord.attributes.<%= model_name.underscore %>.<%= column.name %>", :default => "<%= column.name.humanize %>"), :class => :label
-  .input
-    = f.<%= column.field_type %> :<%= column.name %>, :class => '<%= column.field_type %>'
-<%- end -%>
-
-.form-actions
-  button class="btn primary" type="submit" Save
-  |  or 
-  = link_to "Cancel", <%= controller_routing_path %>_path
+= form_for @<%= resource_name %>, :html => { :class => "form-horizontal" } do |f|
+  fieldset
+    legend
+      = controller.action_name.capitalize
+      | <%= resource_name.titleize %>
+    <%- columns.each do |column| -%>
+    .control-group
+      = f.label :<%= column.name %>, :class => 'control-label'
+      .controls
+        = f.<%= column.field_type %> :<%= column.name %>, :class => '<%= column.field_type %>'
+    <%- end -%>
+    .form-actions
+      = f.submit nil, :class => 'btn btn-primary'
+      '
+      = link_to "Cancel", <%= controller_routing_path %>_path, :class => 'btn'

--- a/lib/generators/bootstrap/themed/templates/edit.html.slim
+++ b/lib/generators/bootstrap/themed/templates/edit.html.slim
@@ -1,3 +1,1 @@
-= form_for @<%= resource_name %>, :url => <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :html => { :class => "edit_<%= resource_name %>", :id => "edit_<%= resource_name %>" } do |f|
-  input name="_method" type="hidden" value="put"
-  = render :partial => "form", :locals => {:f => f}
+= render :partial => "form"

--- a/lib/generators/bootstrap/themed/templates/index.html.erb
+++ b/lib/generators/bootstrap/themed/templates/index.html.erb
@@ -1,10 +1,10 @@
-<h1><%= resource_name.titleize %>s</h1>
+<h1><%= resource_name.pluralize.titleize %></h1>
 <table class="table table-striped">
   <thead>
     <tr>
       <th>ID</th>
       <%- unless columns.empty? -%>
-      <th><%= columns.first.name.humanize %></th>
+      <th><%%= t("activerecord.attributes.<%= singular_controller_routing_path %>.<%= columns.first.name %>", :default => t("activerecord.labels.<%= columns.first.name %>", :default => "<%= columns.first.name.humanize %>")) %></th>
       <%- end -%>
       <th>Created at</th>
       <th>Actions</th>

--- a/lib/generators/bootstrap/themed/templates/index.html.haml
+++ b/lib/generators/bootstrap/themed/templates/index.html.haml
@@ -1,11 +1,11 @@
-%h1 <%= resource_name.titleize %>s
+%h1 <%= resource_name.pluralize.titleize %>
 %table.table.table-striped
   %thead
     %tr
       %th ID
       <%- unless columns.empty? -%>
       %th
-        = t("activerecord.attributes.<%= singular_controller_routing_path %>.<%= columns.first.name %>", :default => t("activerecord.labels.<%= columns.first.name %>", :default => "<%= columns.first.name.capitalize %>"))
+        = t("activerecord.attributes.<%= singular_controller_routing_path %>.<%= columns.first.name %>", :default => t("activerecord.labels.<%= columns.first.name %>", :default => "<%= columns.first.name.humanize %>"))
       <%- end -%>
       %th Created at
       %th Actions
@@ -18,8 +18,7 @@
         <%- end -%>
         %td= <%= resource_name %>.created_at
         %td
-          = link_to "Show", <%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-mini'
           = link_to "Edit", edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-mini'
-          = link_to "Destroy", <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :confirm => "#{t("web-app-theme.confirm", :default => "Are you sure?")}", :class => 'btn btn-mini btn-danger' 
+          = link_to "Destroy", <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :confirm => "Are you sure?", :class => 'btn btn-mini btn-danger'
 
 = link_to "New", new_<%= singular_controller_routing_path %>_path, :class => 'btn btn-primary'

--- a/lib/generators/bootstrap/themed/templates/index.html.slim
+++ b/lib/generators/bootstrap/themed/templates/index.html.slim
@@ -1,11 +1,11 @@
-h1 <%= resource_name.titleize %>s
+h1 <%= resource_name.pluralize.titleize %>
 table class="table table-striped"
   thead
     tr
       th ID
       <%- unless columns.empty? -%>
       th
-        = t("activerecord.attributes.<%= singular_controller_routing_path %>.<%= columns.first.name %>", :default => t("activerecord.labels.<%= columns.first.name %>", :default => "<%= columns.first.name.capitalize %>"))
+        = t("activerecord.attributes.<%= singular_controller_routing_path %>.<%= columns.first.name %>", :default => t("activerecord.labels.<%= columns.first.name %>", :default => "<%= columns.first.name.humanize %>"))
       <%- end -%>
       th Created at
       th Actions
@@ -18,8 +18,9 @@ table class="table table-striped"
         <%- end -%>
         td= <%= resource_name %>.created_at
         td
-          = link_to "Show", <%= singular_controller_routing_path %>_path(<%= resource_name %>)
-          = link_to "Edit", edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>)
-          = link_to "Destroy", <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :confirm => "#{t("web-app-theme.confirm", :default => "Are you sure?")}"
+          = link_to "Edit", edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-mini'
+          '
+          = link_to "Destroy", <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :confirm => "Are you sure?", :class => 'btn btn-mini btn-danger'
 
 = link_to "New", new_<%= singular_controller_routing_path %>_path, :class => 'btn btn-primary'
+

--- a/lib/generators/bootstrap/themed/templates/new.html.slim
+++ b/lib/generators/bootstrap/themed/templates/new.html.slim
@@ -1,2 +1,1 @@
-= form_for @<%= resource_name %>, :url => <%= controller_routing_path %>_path, :html => { :class => :form } do |f|
-  = render :partial => "form", :locals => {:f => f}
+= render :partial => "form"

--- a/lib/generators/bootstrap/themed/templates/show.html.erb
+++ b/lib/generators/bootstrap/themed/templates/show.html.erb
@@ -1,12 +1,12 @@
-<h1><%= model_name.titleize %></h1>
+<h1><%= resource_name.titleize %></h1>
 
 <%- columns.each do |column| -%>
 <p>
-  <b><%= column.name.humanize %></b><br>
+  <strong><%%= t("activerecord.attributes.<%= singular_controller_routing_path %>.<%= column.name %>", :default => t("activerecord.labels.<%= column.name %>", :default => "<%= column.name.humanize %>")) %>:</strong><br>
   <%%= @<%= resource_name %>.<%= column.name %> %>
 </p>
-
 <%- end -%>
+
 <div class="form-actions">
   <%%= link_to 'Back', <%= controller_routing_path %>_path, :class => 'btn'  %>
   <%%= link_to 'Edit', edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), :class => 'btn' %>

--- a/lib/generators/bootstrap/themed/templates/show.html.haml
+++ b/lib/generators/bootstrap/themed/templates/show.html.haml
@@ -1,3 +1,5 @@
+%h1 <%= resource_name.titleize %>
+
 <%- columns.each do |column| -%>
 %p
   %strong= t("activerecord.attributes.<%= singular_controller_routing_path %>.<%= column.name %>", :default => t("activerecord.labels.<%= column.name %>", :default => "<%= column.name.humanize %>")) + ":"
@@ -8,4 +10,6 @@
 .form-actions
   = link_to "Back", <%= controller_routing_path %>_path, :class => 'btn'
   = link_to "Edit", edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), :class => 'btn'
-  = link_to "Delete", <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :method => "delete", :confirm => "#{t("web-app-theme.confirm", :default => "Are you sure?")}", :class => 'btn btn-danger'
+  = link_to "Delete", <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :method => "delete", :confirm => "Are you sure?", :class => 'btn btn-danger'
+
+

--- a/lib/generators/bootstrap/themed/templates/show.html.slim
+++ b/lib/generators/bootstrap/themed/templates/show.html.slim
@@ -1,9 +1,15 @@
+h1 <%= resource_name.titleize %>
+
 <%- columns.each do |column| -%>
-label class="label"= t("activerecord.attributes.<%= singular_controller_routing_path %>.<%= column.name %>", :default => t("activerecord.labels.<%= column.name %>", :default => "<%= column.name.humanize %>")) + ":"
-p= @<%= resource_name %>.<%= column.name %>
+p
+  strong= t("activerecord.attributes.<%= singular_controller_routing_path %>.<%= column.name %>", :default => t("activerecord.labels.<%= column.name %>", :default => "<%= column.name.humanize %>")) + ":"
+  br
+  = @<%= resource_name %>.<%= column.name %>
 <%- end -%>
 
 .form-actions
   = link_to "Back", <%= controller_routing_path %>_path, :class => 'btn'
+  '
   = link_to "Edit", edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), :class => 'btn'
-  = link_to "Delete", <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :method => "delete", :confirm => "#{t("web-app-theme.confirm", :default => "Are you sure?")}", :class => 'btn'
+  '
+  = link_to "Delete", <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :method => "delete", :confirm => "Are you sure?", :class => 'btn btn-danger'


### PR DESCRIPTION
I believe all templating systems should produce the same markup, here's a patch to clean things up and keep all similar.
