### PR TITLE
Patch for issue #180

### DIFF
--- a/vendor/toolkit/fontawesome.less
+++ b/vendor/toolkit/fontawesome.less
@@ -28,11 +28,11 @@
 @font-face {
     font-family: 'FontAwesome';
     src: url(@fontAwesomeEotPath);
-    src: url('#{@fontAwesomeEotPath}?#iefix') format('embedded-opentype'),
+    src: url('@{@fontAwesomeEotPath}?#iefix') format('embedded-opentype'),
          url(@fontAwesomeWoffPath) format('woff'),
          url(@fontAwesomeTtfPath) format('truetype'),
-         url('#{@fontAwesomeSvgzPath}#FontAwesomeRegular') format('svg'),
-         url('#{@fontAwesomeSvgPath}#FontAwesomeRegular') format('svg');
+         url('@{@fontAwesomeSvgzPath}#FontAwesomeRegular') format('svg'),
+         url('@{@fontAwesomeSvgPath}#FontAwesomeRegular') format('svg');
     font-weight: normal;
     font-style: normal;
 }


### PR DESCRIPTION
I moved fontawesome.less under toolkit so that it compiles correctly.  I also fixed the invalid interpolation of the font paths.

Fixes:
[https://github.com/seyhunak/twitter-bootstrap-rails/issues/180](https://github.com/seyhunak/twitter-bootstrap-rails/issues/180)

Sorry about this.

Nick
