### PR TITLE
Hide breadcrumb elements when there aren't any breadcrumbs to show

### DIFF
--- a/app/views/twitter-bootstrap/_breadcrumbs.html.erb
+++ b/app/views/twitter-bootstrap/_breadcrumbs.html.erb
@@ -1,14 +1,14 @@
+<% if @breadcrumbs %>
 <ul class="breadcrumb">
   <% separator = divider %>
-  <% if @breadcrumbs %>
-    <% @breadcrumbs[0..-2].each do |crumb| %>
-      <li>
-        <a href="<%= crumb[:url] %>"><%= crumb[:name] %></a>
-        <span class="divider"><%= separator %></span>
-      </li>
-    <% end %>
-    <li class="active">
-      <a href="<%= @breadcrumbs.last[:url] %>"><%= @breadcrumbs.last[:name] %></a>
-    </li>
+  <% @breadcrumbs[0..-2].each do |crumb| %>
+  <li>
+    <a href="<%= crumb[:url] %>"><%= crumb[:name] %></a>
+    <span class="divider"><%= separator %></span>
+  </li>
   <% end %>
+  <li class="active">
+    <a href="<%= @breadcrumbs.last[:url] %>"><%= @breadcrumbs.last[:name] %></a>
+  </li>
 </ul>
+<% end %>


### PR DESCRIPTION
I noticed a blank patch where `render_breadcrumbs` was called without any breadcrumbs added (on a homepage, for instance).

Perhaps a better default would be to not render anything when empty?
