### PR TITLE
Fix to address sprite issues introduced in #202 that some are experiencing

### DIFF
--- a/vendor/toolkit/twitter/bootstrap/sprites.less
+++ b/vendor/toolkit/twitter/bootstrap/sprites.less
@@ -22,13 +22,13 @@
   .ie7-restore-right-whitespace();
   line-height: 14px;
   vertical-align: text-top;
-  background-image: url(@{iconSpritePath});
+  background-image: url(@iconSpritePath);
   background-position: 14px 14px;
   background-repeat: no-repeat;
 
 }
 .icon-white {
-  background-image: url(@{iconWhiteSpritePath});
+  background-image: url(@iconWhiteSpritePath);
 }
 
 .icon-glass              { background-position: 0      0; }


### PR DESCRIPTION
As discussed [here](https://github.com/seyhunak/twitter-bootstrap-rails/pull/202#issuecomment-5323589), some people are experiencing double double-quotes for the sprite urls.

i.e. `background-image: url(""/assets/twitter/bootstrap/glyphicons-halflings.png"")`

This pull request addresses the bug. Tested with Ruby 1.9.3 / Rails 3.2.3.
