### PR TITLE
1.8 compatibility issue for breadcrumb

### DIFF
--- a/app/helpers/twitter_breadcrumbs_helper.rb
+++ b/app/helpers/twitter_breadcrumbs_helper.rb
@@ -1,5 +1,5 @@
 module TwitterBreadcrumbsHelper
   def render_breadcrumbs(divider = '/')
-    render partial: 'twitter-bootstrap/breadcrumbs', locals: {divider: divider}
+    render partial => 'twitter-bootstrap/breadcrumbs', locals => {divider => divider}
   end
 end


### PR DESCRIPTION
Fixing hash notation for breadcrumb helper
