### PR TITLE
Changed themed generator templates to use the .page-header class

### DIFF
--- a/lib/generators/bootstrap/themed/templates/edit.html.erb
+++ b/lib/generators/bootstrap/themed/templates/edit.html.erb
@@ -1,4 +1,6 @@
 <%%- model_class = @<%= resource_name %>.class -%>
-<h1><%%=t '.title', :default => t('helpers.titles.edit', :model => model_class.model_name.human,
-                                 :default => "Edit #{model_class.model_name.human}") %></h1>
+<div class="page-header">
+  <h1><%%=t '.title', :default => t('helpers.titles.edit', :model => model_class.model_name.human,
+                                   :default => "Edit #{model_class.model_name.human}") %></h1>
+</div>
 <%%= render :partial => 'form' %>

--- a/lib/generators/bootstrap/themed/templates/edit.html.haml
+++ b/lib/generators/bootstrap/themed/templates/edit.html.haml
@@ -1,3 +1,4 @@
 - model_class = @<%= resource_name %>.class
-%h1=t '.title', :default => t('helpers.titles.edit', :model => model_class.model_name.human, :default => "Edit #{model_class.model_name.human}")
+.page-header
+  %h1=t '.title', :default => t('helpers.titles.edit', :model => model_class.model_name.human, :default => "Edit #{model_class.model_name.human}")
 = render :partial => "form"

--- a/lib/generators/bootstrap/themed/templates/edit.html.slim
+++ b/lib/generators/bootstrap/themed/templates/edit.html.slim
@@ -1,3 +1,4 @@
 - model_class = @<%= resource_name %>.class
-h1=t '.title', :default => t('helpers.titles.edit', :model => model_class.model_name.human, :default => "Edit #{model_class.model_name.human}")
+div class="page-header"
+  h1=t '.title', :default => t('helpers.titles.edit', :model => model_class.model_name.human, :default => "Edit #{model_class.model_name.human}")
 = render :partial => "form"

--- a/lib/generators/bootstrap/themed/templates/index.html.erb
+++ b/lib/generators/bootstrap/themed/templates/index.html.erb
@@ -1,5 +1,7 @@
 <%%- model_class = <%= resource_name.classify %>.new.class -%>
-<h1><%%=t '.title', :default => model_class.model_name.human.pluralize %></h1>
+<div class="page-header">
+  <h1><%%=t '.title', :default => model_class.model_name.human.pluralize %></h1>
+</div>
 <table class="table table-striped">
   <thead>
     <tr>

--- a/lib/generators/bootstrap/themed/templates/index.html.haml
+++ b/lib/generators/bootstrap/themed/templates/index.html.haml
@@ -1,5 +1,6 @@
 - model_class = <%= resource_name.classify %>.new.class
-%h1=t '.title', :default => model_class.model_name.human.pluralize
+.page-header
+  %h1=t '.title', :default => model_class.model_name.human.pluralize
 %table.table.table-striped
   %thead
     %tr

--- a/lib/generators/bootstrap/themed/templates/index.html.slim
+++ b/lib/generators/bootstrap/themed/templates/index.html.slim
@@ -1,5 +1,6 @@
 - model_class = <%= resource_name.classify %>.new.class
-h1=t '.title', :default => model_class.model_name.human.pluralize
+div class="page-header"
+  h1=t '.title', :default => model_class.model_name.human.pluralize
 table class="table table-striped"
   thead
     tr

--- a/lib/generators/bootstrap/themed/templates/new.html.erb
+++ b/lib/generators/bootstrap/themed/templates/new.html.erb
@@ -1,4 +1,6 @@
 <%%- model_class = @<%= resource_name %>.class -%>
-<h1><%%=t '.title', :default => t('helpers.titles.new', :model => model_class.model_name.human,
-                               :default => "New #{model_class.model_name.human}") %></h1>
+<div class="page-header">
+  <h1><%%=t '.title', :default => t('helpers.titles.new', :model => model_class.model_name.human,
+                                 :default => "New #{model_class.model_name.human}") %></h1>
+</div>
 <%%= render :partial => 'form' %>

--- a/lib/generators/bootstrap/themed/templates/new.html.haml
+++ b/lib/generators/bootstrap/themed/templates/new.html.haml
@@ -1,3 +1,4 @@
 - model_class = @<%= resource_name %>.class
-%h1=t '.title', :default => t('helpers.titles.new', :model => model_class.model_name.human, :default => "New #{model_class.model_name.human}")
+.page-header
+  %h1=t '.title', :default => t('helpers.titles.new', :model => model_class.model_name.human, :default => "New #{model_class.model_name.human}")
 = render :partial => "form"

--- a/lib/generators/bootstrap/themed/templates/new.html.slim
+++ b/lib/generators/bootstrap/themed/templates/new.html.slim
@@ -1,3 +1,4 @@
 - model_class = @<%= resource_name %>.class
-h1=t '.title', :default => t('helpers.titles.new', :model => model_class.model_name.human, :default => "New #{model_class.model_name.human}")
+div class="page-header"
+  h1=t '.title', :default => t('helpers.titles.new', :model => model_class.model_name.human, :default => "New #{model_class.model_name.human}")
 = render :partial => "form"

--- a/lib/generators/bootstrap/themed/templates/show.html.erb
+++ b/lib/generators/bootstrap/themed/templates/show.html.erb
@@ -1,5 +1,7 @@
 <%%- model_class = @<%= resource_name %>.class -%>
-<h1><%%=t '.title', :default => model_class.model_name.human %></h1>
+<div class="page-header">
+  <h1><%%=t '.title', :default => model_class.model_name.human %></h1>
+</div>
 
 <dl class="dl-horizontal">
 <%- columns.each do |column| -%>

--- a/lib/generators/bootstrap/themed/templates/show.html.haml
+++ b/lib/generators/bootstrap/themed/templates/show.html.haml
@@ -1,5 +1,6 @@
 - model_class = @<%= resource_name %>.class
-%h1=t '.title', :default => model_class.model_name.human
+.page-header
+  %h1=t '.title', :default => model_class.model_name.human
 
 <%- columns.each do |column| -%>
 %p

--- a/lib/generators/bootstrap/themed/templates/show.html.slim
+++ b/lib/generators/bootstrap/themed/templates/show.html.slim
@@ -1,5 +1,6 @@
 - model_class = @<%= resource_name %>.class
-h1=t '.title', :default => model_class.model_name.human
+div class="page-header"
+  h1=t '.title', :default => model_class.model_name.human
 
 <%- columns.each do |column| -%>
 p


### PR DESCRIPTION
It would be great if page titles use the built in Bootstrap header visual style. Just wrapped the titles in div with class of 'page-header'. If you like it merge it to the master branch. 
