### PR TITLE
Instead of using custom a href links, use the link_to helper

### DIFF
--- a/app/views/twitter-bootstrap/_breadcrumbs.html.erb
+++ b/app/views/twitter-bootstrap/_breadcrumbs.html.erb
@@ -3,12 +3,12 @@
   <% separator = divider %>
   <% @breadcrumbs[0..-2].each do |crumb| %>
   <li>
-    <a href="<%= crumb[:url] %>"><%= crumb[:name] %></a>
+    <%= link_to crumb[:name], crumb[:url] %>
     <span class="divider"><%= separator %></span>
   </li>
   <% end %>
   <li class="active">
-    <a href="<%= @breadcrumbs.last[:url] %>"><%= @breadcrumbs.last[:name] %></a>
+    <%= link_to @breadcrumbs.last[:name], @breadcrumbs.last[:url] %>
   </li>
 </ul>
 <% end %>


### PR DESCRIPTION
This way we can pass it a url or an object, allowing us to use the power of rails routes.

Now something like this works

``` ruby
    @campaign = Campaign.find(params[:id])
    add_breadcrumb @campaign.name, @campaign
```
