### PR TITLE
Added 'badge-important' class

### DIFF
--- a/vendor/toolkit/twitter/bootstrap/badges.less
+++ b/vendor/toolkit/twitter/bootstrap/badges.less
@@ -23,6 +23,10 @@
 .badge-error            { background-color: @errorText; }
 .badge-error:hover      { background-color: darken(@errorText, 10%); }
 
+// Colors
+.badge-important        { background-color: @errorText; }
+.badge-important:hover  { background-color: darken(@errorText, 10%); }
+
 .badge-warning          { background-color: @orange; }
 .badge-warning:hover    { background-color: darken(@orange, 10%); }
 


### PR DESCRIPTION
I got stung by this a little earlier. In the bootstrap docs (http://twitter.github.com/bootstrap/components.html#badges) for badges there is a `badge-important` class which seems to have been renamed to `badge-error` in twitter-bootstrap rails. I have just made a super simple`badge-important` class which is an exact copy of `badge-error`, so the gem and the docs line up. Useful for me but perhaps too small a change for the project :).
