### PR TITLE
Add CSS 20px of space on the left side of pages.  

### DIFF
--- a/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
+++ b/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
@@ -1,5 +1,8 @@
 @import "twitter/bootstrap/bootstrap";
-body { padding-top: 60px; }
+body { 
+	padding-top: 60px;
+	padding-left: 20px;
+}
 
 @import "twitter/bootstrap/responsive";
 


### PR DESCRIPTION
I think it would be nice to add 20px of space on the left side of pages by default. Currently page content is on top of the brower's left side. This is a small detail, but I believe worth adding.
