### PR TITLE
String interpolation problem with fontawesome.less yielding 404 errors from rails - fixed

### DIFF
--- a/vendor/toolkit/fontawesome.less
+++ b/vendor/toolkit/fontawesome.less
@@ -28,11 +28,11 @@
 @font-face {
     font-family: 'FontAwesome';
     src: url(@fontAwesomeEotPath);
-    src: url('@{@fontAwesomeEotPath}?#iefix') format('embedded-opentype'),
+    src: url('@{fontAwesomeEotPath}?#iefix') format('embedded-opentype'),
          url(@fontAwesomeWoffPath) format('woff'),
          url(@fontAwesomeTtfPath) format('truetype'),
-         url('@{@fontAwesomeSvgzPath}#FontAwesomeRegular') format('svg'),
-         url('@{@fontAwesomeSvgPath}#FontAwesomeRegular') format('svg');
+         url('@{fontAwesomeSvgzPath}#FontAwesomeRegular') format('svg'),
+         url('@{fontAwesomeSvgPath}#FontAwesomeRegular') format('svg');
     font-weight: normal;
     font-style: normal;
 }


### PR DESCRIPTION
Using the following set in bootstrap_and_overrides.css.less:

@fontAwesomeEotPath: asset_path('fontawesome-webfont.eot');
@fontAwesomeWoffPath: asset_path('fontawesome-webfont.woff');
@fontAwesomeTtfPath: asset_path('fontawesome-webfont.ttf');
@fontAwesomeSvgzPath: asset_path('fontawesome-webfont.svgz');
@fontAwesomeSvgPath: asset_path('fontawesome-webfont.svg');

The current fontawesome.less of:

@font-face {
    font-family: 'FontAwesome';
    src: url(@fontAwesomeEotPath);
    src: url('@{@fontAwesomeEotPath}?#iefix') format('embedded-opentype'),
         url(@fontAwesomeWoffPath) format('woff'),
         url(@fontAwesomeTtfPath) format('truetype'),
         url('@{@fontAwesomeSvgzPath}#FontAwesomeRegular') format('svg'),
         url('@{@fontAwesomeSvgPath}#FontAwesomeRegular') format('svg');
    font-weight: normal;
    font-style: normal;
}

was yielding:

src:url('assets/fontawesome-webfont.eot');
src:url('@{@fontAwesomeEotPath}?#iefix') format('embedded-opentype'),
    url('assets/fontawesome-webfont.woff') format('woff'),
    url('assets/fontawesome-webfont.ttf') format('truetype'),
    url('@{@fontAwesomeSvgzPath}#FontAwesomeRegular') format('svg'),
    url('@{@fontAwesomeSvgPath}#FontAwesomeRegular') format('svg');

which results in:

Served asset /@{@fontAwesomeEotPath} - 404 Not Found

So I fixed it :)
