### PR TITLE
fixing a mismatch of "require_tree ." when there is something more after.

### DIFF
--- a/lib/generators/bootstrap/install/install_generator.rb
+++ b/lib/generators/bootstrap/install/install_generator.rb
@@ -18,7 +18,7 @@ module Bootstrap
         if File.exist?('app/assets/stylesheets/application.css')
           # Add our own require:
           content = File.read("app/assets/stylesheets/application.css")
-          if content.match(/require_tree\s+\./)
+          if content.match(/require_tree\s+\.\s*$/)
             # Good enough - that'll include our bootstrap_and_overrides.css.less
           else
             style_require_block = " *= require bootstrap_and_overrides\n"


### PR DESCRIPTION
it was matching "require_tree ./something_else" as "require_tree ." and skipping bootstrap insertion on css.
