### PR TITLE
remove "Bell Character" (octal 007) from end of haml layout template

### DIFF
--- a/lib/generators/bootstrap/layout/templates/layout.html.haml
+++ b/lib/generators/bootstrap/layout/templates/layout.html.haml
@@ -63,4 +63,3 @@
       \==================================================
     / Placed at the end of the document so the pages load faster
     = javascript_include_tag "application"
-


### PR DESCRIPTION
Was that in there for a reason?
