### PR TITLE
Use therubyrhino instead of therubyracer for jruby

### DIFF
--- a/twitter-bootstrap-rails.gemspec
+++ b/twitter-bootstrap-rails.gemspec
@@ -20,7 +20,11 @@ Gem::Specification.new do |s|
 
   s.add_dependency             'railties',   '>= 3.1'
   s.add_dependency             'actionpack', '>= 3.1'
-  s.add_dependency             'therubyracer', '~> 0.10.1'
+  if (RUBY_PLATFORM == 'java')
+    s.add_dependency             'therubyrhino', '~> 1.73.4'
+  else
+    s.add_dependency             'therubyracer', '~> 0.10.1'
+  end
   s.add_runtime_dependency     'less-rails', '~> 2.2.2'
   s.add_development_dependency 'rails', '>= 3.1'
 end


### PR DESCRIPTION
Both projects are owned by cowboyd and are supposed to be compatible.

As far as I know, therubyracer doesn't work on jruby.
