### PR TITLE
Fixes for bootstrap issues #3806 and #3819/twitter-bootstrap-rails issues #274 and #275

### DIFF
--- a/vendor/toolkit/twitter/bootstrap/type.less
+++ b/vendor/toolkit/twitter/bootstrap/type.less
@@ -145,6 +145,11 @@ dd {
   dd {
     margin-left: 130px;
   }
+  &:after {
+    display: table;
+    content: "";
+    clear: both;
+  }
 }
 
 // MISC


### PR DESCRIPTION
A few fixes for dl-horizontal float issue and commenting out a fix for a font issue with dt in bootstrap. They work, but I'd like to see what the bootstrap guys say about 3806, because it is commenting out a fix they added for another bug- although their fix was to have uneven line-height between dd and dt which seems wrong, but what do I know...

Associated tickets:
https://github.com/twitter/bootstrap/issues/3806
https://github.com/twitter/bootstrap/issues/3819
https://github.com/seyhunak/twitter-bootstrap-rails/issues/274
https://github.com/seyhunak/twitter-bootstrap-rails/issues/275
