### PR TITLE
use asset-url to correctly set url paths for fonts

### DIFF
--- a/vendor/toolkit/fontawesome.less
+++ b/vendor/toolkit/fontawesome.less
@@ -24,11 +24,11 @@
 
 @font-face {
   font-family: 'FontAwesome';
-  src: url(@fontAwesomeEotPath);
-  src: url('@{@fontAwesomeEotPath}?#iefix') format('embedded-opentype'),
-    url(@fontAwesomeWoffPath) format('woff'),
-    url(@fontAwesomeTtfPath) format('truetype'),
-    url('@{@fontAwesomeSvgPath}#FontAwesome') format('svg');
+  src: asset-url(@fontAwesomeEotPath);
+  src: asset-url("@{fontAwesomeEotPath}?#iefix") format('embedded-opentype'),
+    asset-url(@fontAwesomeWoffPath) format('woff'),
+    asset-url(@fontAwesomeTtfPath) format('truetype'),
+    asset-url('@{fontAwesomeSvgPath}#FontAwesome') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
setting font paths like so:

```
@fontAwesomeEotPath:  'fontawesome-webfont.eot';
@fontAwesomeWoffPath: 'fontawesome-webfont.woff';
@fontAwesomeTtfPath:  'fontawesome-webfont.ttf';
@fontAwesomeSvgzPath: 'fontawesome-webfont.svgz';
@fontAwesomeSvgPath:  'fontawesome-webfont.svg';
```

correctly yields the appropriate paths - eliminating need to hardcode which makes my paths work on my CDN
