### PR TITLE
Addressing issue #278 - The carousel does not 'slide' when using therubyracer 0.10.1

### DIFF
--- a/twitter-bootstrap-rails.gemspec
+++ b/twitter-bootstrap-rails.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   if (RUBY_PLATFORM == 'java')
     s.add_dependency             'therubyrhino', '~> 1.73.4'
   else
-    s.add_dependency             'therubyracer', '~> 0.10.1'
+    s.add_dependency             'therubyracer', '~> 0.10.0'
   end
   s.add_runtime_dependency     'less-rails', '~> 2.2.2'
   s.add_development_dependency 'rails', '>= 3.1'


### PR DESCRIPTION
Addressing issue #278 - The carousel does not 'slide' when using therubyracer version 0.10.1.
