### PR TITLE
TypeError: can't convert Symbol into String

### DIFF
--- a/app/views/twitter-bootstrap/_breadcrumbs.html.erb
+++ b/app/views/twitter-bootstrap/_breadcrumbs.html.erb
@@ -4,7 +4,7 @@
     <% @breadcrumbs[0..-2].each do |crumb| %>
       <li>
       	<%= link_to crumb[:name], crumb[:url], crumb[:options] %>
-        <span class="divider"><%= separator.html_safe %></span>
+        <span class="divider"><%= separator %></span>
       </li>
     <% end %>
     <li class="active">


### PR DESCRIPTION
When using the breadcrumbs in the controller like

``` ruby
add_breadcrumb 'Dashboard', :dashboard_path
```

The second argument is being passed to eval(). Since a symbol can't be passed to eval() you get this error. My patch just called .to_s on the url being passed to eval to allow symbols or strings.
