### PR TITLE
removal of padding override to restore bootstrap navbar's expected behavior

### DIFF
--- a/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
+++ b/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
@@ -1,7 +1,6 @@
 @import "twitter/bootstrap/bootstrap";
 body { 
 	padding-top: 60px;
-	padding-left: 20px;
 }
 
 @import "twitter/bootstrap/responsive";


### PR DESCRIPTION
The inclusion of 20px padding-left breaks the navbar. Instead of spanning the entire page, the bar breaks at certain resolutions (reproducible at tablet scale).

I suggest we remove this padding override in order to preserve functionality of the standard bootstrap nav bar.
