### PR TITLE
On Windows 'therubyracer' is not supported. 

### DIFF
--- a/twitter-bootstrap-rails.gemspec
+++ b/twitter-bootstrap-rails.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency             'actionpack', '>= 3.1'
   if (RUBY_PLATFORM == 'java')
     s.add_dependency             'therubyrhino', '~> 1.73.4'
-  else
-    s.add_dependency             'therubyracer', '0.10.1'
   end
   s.add_runtime_dependency     'less-rails', '~> 2.2.2'
   s.add_development_dependency 'rails', '>= 3.1'


### PR DESCRIPTION
It's better to leave to the user to choose to install it or not. Even better is node.js today, that support Windows very well.
