### PR TITLE
Typeahead field population fix

### DIFF
--- a/vendor/assets/javascripts/twitter/bootstrap/bootstrap-typeahead.js
+++ b/vendor/assets/javascripts/twitter/bootstrap/bootstrap-typeahead.js
@@ -230,7 +230,11 @@
 
   , blur: function (e) {
       var that = this
-      setTimeout(function () { that.hide() }, 150)
+      setTimeout(function () {
+        if (!that.$menu.is(':hover')) {
+          that.hide();
+        }
+      }, 150)
     }
 
   , click: function (e) {


### PR DESCRIPTION
This fixes an issue where clicking and holding would cause typeahead to not populate the field.

Implementation from @mckramer
Posted originally on bootstrap issue #2715
https://github.com/twitter/bootstrap/issues/2715

This fix should probably get merged into bootstrap, but until it does, no reason we shouldn't take advantage here. Myself and others have tested the fix successfully. More details can be found in the issue above.
