### PR TITLE
Fixed typo on 'bootstap_flash'

### DIFF
--- a/lib/generators/bootstrap/layout/templates/layout.html.erb
+++ b/lib/generators/bootstrap/layout/templates/layout.html.erb
@@ -70,7 +70,7 @@
           </div><!--/.well -->
         </div><!--/span-->
         <div class="span9">
-          <%%= bootstap_flash %>
+          <%%= bootstrap_flash %>
           <%%= yield %>
         </div>
       </div><!--/row-->

--- a/lib/generators/bootstrap/layout/templates/layout.html.haml
+++ b/lib/generators/bootstrap/layout/templates/layout.html.haml
@@ -49,7 +49,7 @@
       .content
         .row
           .span9
-            = bootstap_flash
+            = bootstrap_flash
             = yield
           .span3
             .well.sidebar-nav

--- a/lib/generators/bootstrap/layout/templates/layout.html.slim
+++ b/lib/generators/bootstrap/layout/templates/layout.html.slim
@@ -49,7 +49,7 @@ html lang="en"
       .content
         .row
           .span9
-            = bootstap_flash
+            = bootstrap_flash
             = yield
           .span3
             .well.sidebar-nav


### PR DESCRIPTION
Layout templates had a typo on the bootstrap_flash method causing generated layouts to fail.
