### PR TITLE
Fixes an error with asset compilation

### DIFF
--- a/vendor/toolkit/twitter/bootstrap/sprites.less
+++ b/vendor/toolkit/twitter/bootstrap/sprites.less
@@ -36,7 +36,7 @@
 .dropdown-menu > li > a:hover > [class*=" icon-"],
 .dropdown-menu > .active > a > [class^="icon-"],
 .dropdown-menu > .active > a > [class*=" icon-"] {
-  background-image: url("@{iconWhiteSpritePath}");
+  background-image: url(@iconWhiteSpritePath);
 }
 
 .icon-glass              { background-position: 0      0; }


### PR DESCRIPTION
The following error is fixed:

```
rake aborted!
Invalid CSS after "...nd-image:url(""": expected ")", was "/assets/twitter..."
  (in /home/phoenix/investopresto/app/assets/stylesheets/application.css.scss)
(sass):1311
```
