### PR TITLE
therubiracer depedencies

### DIFF
--- a/twitter-bootstrap-rails.gemspec
+++ b/twitter-bootstrap-rails.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |s|
   
   if (RUBY_PLATFORM == 'java')
     s.add_dependency          'therubyrhino', '~> 1.73.4'
+  else
+    s.add_dependency  'therubyracer', '~> 0.10.2'
   end
   
   s.add_runtime_dependency     'less-rails', '~> 2.2.3'


### PR DESCRIPTION
fix
$ rails s
[WARNING] Please install gem 'therubyracer' to use Less.
/home/anton/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.5/lib/bundler/runtime.rb:74:in `require': cannot load such file -- twitter/bootstrap/rails (LoadError)
    from /home/anton/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.5/lib/bundler/runtime.rb:74:in`rescue in block in require'
    from /home/anton/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.5/lib/bundler/runtime.rb:62:in `block in require'
    from /home/anton/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.5/lib/bundler/runtime.rb:55:in`each'
    from /home/anton/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.5/lib/bundler/runtime.rb:55:in `require'
    from /home/anton/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.5/lib/bundler.rb:119:in`require'
    from /home/anton/work/tradein/config/application.rb:7:in `<top (required)>'
    from /home/anton/.rvm/gems/ruby-1.9.3-p194@r328/gems/railties-3.2.8/lib/rails/commands.rb:53:in`require'
    from /home/anton/.rvm/gems/ruby-1.9.3-p194@r328/gems/railties-3.2.8/lib/rails/commands.rb:53:in `block in <top (required)>'
    from /home/anton/.rvm/gems/ruby-1.9.3-p194@r328/gems/railties-3.2.8/lib/rails/commands.rb:50:in`tap'
    from /home/anton/.rvm/gems/ruby-1.9.3-p194@r328/gems/railties-3.2.8/lib/rails/commands.rb:50:in `<top (required)>'
    from script/rails:6:in`require'
    from script/rails:6:in `<main>'
