### PR TITLE
Bug on bootstrap-dropdown.js

### DIFF
--- a/vendor/assets/javascripts/twitter/bootstrap/bootstrap-dropdown.js
+++ b/vendor/assets/javascripts/twitter/bootstrap/bootstrap-dropdown.js
@@ -100,8 +100,7 @@
   }
 
   function clearMenus() {
-    getParent($(toggle))
-      .removeClass('open')
+    $(toggle).closest('.dropdown').removeClass('open');
   }
 
   function getParent($this) {


### PR DESCRIPTION
If I have 3 differents dropdowns in my page, the bootstrap-dropdown.js is
clearing only the first dropdown even if the others dropdowns was
opened.

This commit changes the 'clearMenus' function to seek the closests
element with '.dropdown' class and then clears it.
