### PR TITLE
Update link to less variables on the documentation

### DIFF
--- a/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
+++ b/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
@@ -1,5 +1,5 @@
 @import "twitter/bootstrap/bootstrap";
-body { 
+body {
 	padding-top: 60px;
 }
 
@@ -10,7 +10,7 @@ body {
 @iconWhiteSpritePath: asset-path('twitter/bootstrap/glyphicons-halflings-white.png');
 
 // Set the Font Awesome (Font Awesome is default. You can disable by commenting below lines)
-// Note: If you use asset_path() here, your compiled boostrap_and_overrides.css will not 
+// Note: If you use asset_path() here, your compiled boostrap_and_overrides.css will not
 //       have the proper paths. So for now we use the absolute path.
 @fontAwesomeEotPath: '/assets/fontawesome-webfont.eot';
 @fontAwesomeWoffPath: '/assets/fontawesome-webfont.woff';
@@ -26,7 +26,7 @@ body {
 // you may use and inherit here
 //
 // If you'd like to override bootstrap's own variables, you can do so here as well
-// See http://twitter.github.com/bootstrap/less.html for their names and documentation
+// See http://twitter.github.com/bootstrap/customize.html#variables for their names and documentation
 //
 // Example:
 // @linkColor: #ff0000;


### PR DESCRIPTION
The link to the less variables was removed  from the documentation in this commit - https://github.com/twitter/bootstrap/commit/8495c02003f5b897b532cbb4b104dfbd258814b9#less.html

This pull request:
- Updates the link to http://twitter.github.com/bootstrap/customize.html#variables which is the next closes thing I could find in the documentation
- Cleans up a small amount of whitespace in the file.
