### PR TITLE
Fix link to Code Climate in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ twitter-bootstrap-rails project integrates Bootstrap CSS toolkit for Rails 3.1 A
 
 [![Build Status](https://secure.travis-ci.org/seyhunak/twitter-bootstrap-rails.png)](http://travis-ci.org/seyhunak/twitter-bootstrap-rails)
 [![Dependency Status](https://gemnasium.com/seyhunak/twitter-bootstrap-rails.png)](https://gemnasium.com/seyhunak/twitter-bootstrap-rails)
-[![Code Climate](https://codeclimate.com/badge.png)](https://github.com/seyhunak/twitter-bootstrap-rails)
+[![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/seyhunak/twitter-bootstrap-rails)
 
 ## Screencasts
 #### Installing twitter-bootstrap-rails, generators, usage and more


### PR DESCRIPTION
The Code Climate link was set to the GitHub repository
instead of the Code Climate page for this project.
