### PR TITLE
Remove padding-top since is no more needed

### DIFF
--- a/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
+++ b/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
@@ -1,8 +1,4 @@
 @import "twitter/bootstrap/bootstrap";
-body {
-	padding-top: 60px;
-}
-
 @import "twitter/bootstrap/responsive";
 
 // Set the correct sprite paths


### PR DESCRIPTION
Since [Twitter Bootstrap 2.1.1](http://twitter.github.com/bootstrap/components.html#navbar) navbars are static (not fixed to the top) so this hack is unnecessary.

For a new installation, the padding-top [push down](https://skitch.com/ovargas27/ewnpb/tb-rails) the navbar and looks weird

There are still the class `navbar-fixed-top` but is, from my point of view,  more for backward compatibility,  
