### PR TITLE
Update app/helpers/bootstrap_flash_helper.rb

### DIFF
--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -1,10 +1,13 @@
+# encoding: utf-8
 module BootstrapFlashHelper  
   def bootstrap_flash
    flash_messages = []
    flash.each do |type, message|
      type = :success if type == :notice
      type = :error   if type == :alert
-     text = content_tag(:div, link_to("&times;", "#", :class => "close", "data-dismiss" => "alert") + message, :class => "alert fade in alert-#{type}")
+     text = content_tag(:div, 
+              content_tag(:button, "×", :class => "close", "data-dismiss" => "alert") +
+              message, :class => "alert fade in alert-#{type}")
      flash_messages << text if message
    end
    flash_messages.join("\n").html_safe


### PR DESCRIPTION
Is the best way for pretty close elem like bootstrap
1. # encoding: utf-8 – for support "×" symbol
2. original twitter bootstrap use the button for close,
link_to is the bad way. Link have a underline, underline for close is bad.
