### PR TITLE
Close button regression in bootstrap_flash 

### DIFF
--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -4,7 +4,7 @@ module BootstrapFlashHelper
    flash.each do |type, message|
      type = :success if type == :notice
      type = :error   if type == :alert
-     text = content_tag(:div, link_to("&times;", "#", :class => "close", "data-dismiss" => "alert") + message, :class => "alert fade in alert-#{type}")
+     text = content_tag(:div, link_to(raw("&times;"), "#", :class => "close", "data-dismiss" => "alert") + message, :class => "alert fade in alert-#{type}")
      flash_messages << text if message
    end
    flash_messages.join("\n").html_safe


### PR DESCRIPTION
The pull from earlier today outputs the escaped entity. raw() should be used here to prevent escaping the &times; in link_to
