### PR TITLE
Updated to support turbolinks for rails 4 with graceful fallback

### DIFF
--- a/lib/generators/bootstrap/install/templates/bootstrap.coffee
+++ b/lib/generators/bootstrap/install/templates/bootstrap.coffee
@@ -1,4 +1,8 @@
-jQuery ->
+initTooltips = ->
   $("a[rel=popover]").popover()
   $(".tooltip").tooltip()
   $("a[rel=tooltip]").tooltip()
+
+jQuery -> initTooltips()
+
+$(document).on 'page:load', initTooltips

--- a/vendor/assets/javascripts/twitter/bootstrap/bootstrap-affix.js
+++ b/vendor/assets/javascripts/twitter/bootstrap/bootstrap-affix.js
@@ -85,20 +85,21 @@
 
  /* AFFIX DATA-API
   * ============== */
-
-  $(window).on('load', function () {
+  function bootstrapInitAffix() {
     $('[data-spy="affix"]').each(function () {
-      var $spy = $(this)
-        , data = $spy.data()
+      var $spy = $(this),
+        data = $spy.data();
 
-      data.offset = data.offset || {}
+      data.offset = data.offset || {};
 
-      data.offsetBottom && (data.offset.bottom = data.offsetBottom)
-      data.offsetTop && (data.offset.top = data.offsetTop)
+      data.offsetBottom && (data.offset.bottom = data.offsetBottom);
+      data.offsetTop && (data.offset.top = data.offsetTop);
 
-      $spy.affix(data)
-    })
-  })
+      $spy.affix(data);
+    });
+  }
 
+  $(window).on('load', bootstrapInitAffix);
+  $(document).on('page:load',bootstrapInitAffix);
 
 }(window.jQuery);

--- a/vendor/assets/javascripts/twitter/bootstrap/bootstrap-alert.js
+++ b/vendor/assets/javascripts/twitter/bootstrap/bootstrap-alert.js
@@ -82,9 +82,11 @@
 
  /* ALERT DATA-API
   * ============== */
+  function bootstrapInitAlert() {
+    $('body').on('click.alert.data-api', dismiss, Alert.prototype.close);
+  }
 
-  $(function () {
-    $('body').on('click.alert.data-api', dismiss, Alert.prototype.close)
-  })
+  $(bootstrapInitAlert);
+  $(document).on('page:load',bootstrapInitAlert);
 
 }(window.jQuery);

--- a/vendor/assets/javascripts/twitter/bootstrap/bootstrap-button.js
+++ b/vendor/assets/javascripts/twitter/bootstrap/bootstrap-button.js
@@ -84,13 +84,15 @@
 
  /* BUTTON DATA-API
   * =============== */
-
-  $(function () {
+  function bootstrapInitButton() {
     $('body').on('click.button.data-api', '[data-toggle^=button]', function ( e ) {
-      var $btn = $(e.target)
-      if (!$btn.hasClass('btn')) $btn = $btn.closest('.btn')
-      $btn.button('toggle')
-    })
-  })
+      var $btn = $(e.target);
+      if (!$btn.hasClass('btn')) $btn = $btn.closest('.btn');
+      $btn.button('toggle');
+    });
+  }
+
+  $(bootstrapInitButton);
+  $(document).on('page:load',bootstrapInitButton);
 
 }(window.jQuery);

--- a/vendor/assets/javascripts/twitter/bootstrap/bootstrap-carousel.js
+++ b/vendor/assets/javascripts/twitter/bootstrap/bootstrap-carousel.js
@@ -162,15 +162,17 @@
 
  /* CAROUSEL DATA-API
   * ================= */
-
-  $(function () {
+  function bootstrapInitCarousel() {
     $('body').on('click.carousel.data-api', '[data-slide]', function ( e ) {
       var $this = $(this), href
         , $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
         , options = !$target.data('modal') && $.extend({}, $target.data(), $this.data())
-      $target.carousel(options)
-      e.preventDefault()
-    })
-  })
+      $target.carousel(options);
+      e.preventDefault();
+    });
+  }
+
+  $(bootstrapInitCarousel);
+  $(document).on('page:load',bootstrapInitCarousel);
 
 }(window.jQuery);

--- a/vendor/assets/javascripts/twitter/bootstrap/bootstrap-collapse.js
+++ b/vendor/assets/javascripts/twitter/bootstrap/bootstrap-collapse.js
@@ -142,8 +142,7 @@
 
  /* COLLAPSIBLE DATA-API
   * ==================== */
-
-  $(function () {
+  function bootstrapInitCollapse() {
     $('body').on('click.collapse.data-api', '[data-toggle=collapse]', function (e) {
       var $this = $(this), href
         , target = $this.attr('data-target')
@@ -153,6 +152,8 @@
       $this[$(target).hasClass('in') ? 'addClass' : 'removeClass']('collapsed')
       $(target).collapse(option)
     })
-  })
+  }
+  $(bootstrapInitCollapse);
+  $(document).on('page:load',bootstrapInitCollapse);
 
 }(window.jQuery);

--- a/vendor/assets/javascripts/twitter/bootstrap/bootstrap-dropdown.js
+++ b/vendor/assets/javascripts/twitter/bootstrap/bootstrap-dropdown.js
@@ -137,14 +137,15 @@
 
   /* APPLY TO STANDARD DROPDOWN ELEMENTS
    * =================================== */
-
-  $(function () {
+   function bootstrapInitDropdown() {
     $('html')
       .on('click.dropdown.data-api touchstart.dropdown.data-api', clearMenus)
     $('body')
       .on('click.dropdown touchstart.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
       .on('click.dropdown.data-api touchstart.dropdown.data-api'  , toggle, Dropdown.prototype.toggle)
       .on('keydown.dropdown.data-api touchstart.dropdown.data-api', toggle + ', [role=menu]' , Dropdown.prototype.keydown)
-  })
+   }
+  $(bootstrapInitDropdown);
+  $(document).on('page:load',bootstrapInitDropdown);
 
 }(window.jQuery);

--- a/vendor/assets/javascripts/twitter/bootstrap/bootstrap-modal.js
+++ b/vendor/assets/javascripts/twitter/bootstrap/bootstrap-modal.js
@@ -218,8 +218,7 @@
 
  /* MODAL DATA-API
   * ============== */
-
-  $(function () {
+  function bootstrapInitModal() {
     $('body').on('click.modal.data-api', '[data-toggle="modal"]', function ( e ) {
       var $this = $(this)
         , href = $this.attr('href')
@@ -234,6 +233,9 @@
           $this.focus()
         })
     })
-  })
+  }
+
+  $(bootstrapInitModal);
+  $(document).bind('page:load',bootstrapInitModal);
 
 }(window.jQuery);

--- a/vendor/assets/javascripts/twitter/bootstrap/bootstrap-scrollspy.js
+++ b/vendor/assets/javascripts/twitter/bootstrap/bootstrap-scrollspy.js
@@ -140,12 +140,13 @@
 
  /* SCROLLSPY DATA-API
   * ================== */
-
-  $(window).on('load', function () {
+  function initScrollSpy() {
     $('[data-spy="scroll"]').each(function () {
       var $spy = $(this)
       $spy.scrollspy($spy.data())
     })
-  })
+  }
+  $(window).on('load', initScrollSpy);
+  $(document).on('page:load',initScrollSpy);
 
 }(window.jQuery);

--- a/vendor/assets/javascripts/twitter/bootstrap/bootstrap-tab.js
+++ b/vendor/assets/javascripts/twitter/bootstrap/bootstrap-tab.js
@@ -124,12 +124,14 @@
 
  /* TAB DATA-API
   * ============ */
-
-  $(function () {
+  function bootstrapInitTab() {
     $('body').on('click.tab.data-api', '[data-toggle="tab"], [data-toggle="pill"]', function (e) {
-      e.preventDefault()
-      $(this).tab('show')
-    })
-  })
+      e.preventDefault();
+      $(this).tab('show');
+    });
+  }
+
+  $(bootstrapInitTab);
+  $(document).on('page:load',bootstrapInitTab);
 
 }(window.jQuery);

--- a/vendor/assets/javascripts/twitter/bootstrap/bootstrap-typeahead.js
+++ b/vendor/assets/javascripts/twitter/bootstrap/bootstrap-typeahead.js
@@ -287,14 +287,16 @@
 
  /*   TYPEAHEAD DATA-API
   * ================== */
-
-  $(function () {
+  function bootstrapInitTypeAhead() {
     $('body').on('focus.typeahead.data-api', '[data-provide="typeahead"]', function (e) {
-      var $this = $(this)
-      if ($this.data('typeahead')) return
-      e.preventDefault()
-      $this.typeahead($this.data())
-    })
-  })
+      var $this = $(this);
+      if ($this.data('typeahead')) return;
+      e.preventDefault();
+      $this.typeahead($this.data());
+    });
+  }
+
+  $(bootstrapInitTypeAhead)
+  $(document).on('page:load',bootstrapInitTypeAhead);
 
 }(window.jQuery);


### PR DESCRIPTION
This is replacing my previous pull request and restoring Readme.md / gemspec definitions. They were changed temporarily to get a gem out in the interim until this patch got out into the wild.

It allows for rails 4 turbolinks support, which is going to become standard. It also gracefully falls back and has no affect on sites that do not use turbolinks. It does require changing the twitter bootstrap source files themselves slightly. I will see about submitting these patches to twitter bootstrap repository itself in the future.

Thanks,
David
