### PR TITLE
skip Devise :timeout flash message

### DIFF
--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -2,6 +2,8 @@ module BootstrapFlashHelper
   def bootstrap_flash
    flash_messages = []
    flash.each do |type, message|
+     # Skip Devise :timeout flag
+     next if type == :timeout
      type = :success if type == :notice
      type = :error   if type == :alert
      text = content_tag(:div, 


### PR DESCRIPTION
Devise uses :timeout as a flag and has a boolean value that should be ignored.
