### PR TITLE
fix layout type names of fixed and fluid in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Layout (generates Twitter Bootstrap compatible layout) - (Haml and Slim supporte
 Usage:
 
 
-    rails g bootstrap:layout [LAYOUT_NAME] [*ﬁxed or ﬂuid]
+    rails g bootstrap:layout [LAYOUT_NAME] [*fixed or fluid]
 
 
 Example:


### PR DESCRIPTION
Fix layout type names of fixed and fluid in README.md (issue #414)

Thanks.
