### PR TITLE
Don't include sprites.less if using Font Awesome

### DIFF
--- a/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
+++ b/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
@@ -16,6 +16,9 @@
 // Font Awesome
 @import "fontawesome";
 
+// Glyphicons
+//@import "twitter/bootstrap/sprites.less";
+
 // Your custom LESS stylesheets goes here
 //
 // Since bootstrap was imported above you have access to its mixins which

--- a/vendor/toolkit/twitter/bootstrap/bootstrap.less
+++ b/vendor/toolkit/twitter/bootstrap/bootstrap.less
@@ -27,7 +27,6 @@
 @import "tables.less";
 
 // Components: common
-@import "sprites.less";
 @import "dropdowns.less";
 @import "wells.less";
 @import "component-animations.less";


### PR DESCRIPTION
According to the [documentation](http://fortawesome.github.com/Font-Awesome/#integration) on Font Awesome step 3 you are supposed to replace the include of sprites.less in the main bootstrap.less file with the fontawesome.less include.   I was getting double rendering of both the font and the sprite. 

Since fontawesome.less is included in bootstrap_and_overrides.less; sprites.less should also be included there.  The user should be able to choose their icon source.

This pull moves this configuration choice to bootstrap_and_overrides.less.  It alleviates the problem of the font and icon both being rendered.  The default is still fontawesome.less

Thanks,
Nick
