### PR TITLE
removed sprites.less

### DIFF
--- a/vendor/toolkit/twitter/bootstrap/bootstrap.less
+++ b/vendor/toolkit/twitter/bootstrap/bootstrap.less
@@ -27,7 +27,6 @@
 @import "tables.less";
 
 // Components: common
-@import "sprites.less";
 @import "dropdowns.less";
 @import "wells.less";
 @import "component-animations.less";


### PR DESCRIPTION
The new 2.1.5 version still presents issue #402 , that has other side effects (#408 should be related too)

`sprites.less` is back: https://github.com/seyhunak/twitter-bootstrap-rails/blob/master/vendor/toolkit/twitter/bootstrap/bootstrap.less#L30

this pull request removes sprites.less (again :P)
