### PR TITLE
Drop .png extension from sprite paths

### DIFF
--- a/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
+++ b/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
@@ -2,8 +2,8 @@
 @import "twitter/bootstrap/responsive";
 
 // Set the correct sprite paths
-@iconSpritePath: asset-path("twitter/bootstrap/glyphicons-halflings.png");
-@iconWhiteSpritePath: asset-path("twitter/bootstrap/glyphicons-halflings-white.png");
+@iconSpritePath: asset-path("twitter/bootstrap/glyphicons-halflings");
+@iconWhiteSpritePath: asset-path("twitter/bootstrap/glyphicons-halflings-white");
 
 // Set the Font Awesome (Font Awesome is default. You can disable by commenting below lines)
 // Note: If you use asset_path() here, your compiled boostrap_and_overrides.css will not


### PR DESCRIPTION
Solves a bug with LESS syntax that less-rails parser
Came up in SO: http://stackoverflow.com/questions/10959224/override-less-variables-in-twitter-bootstrap-rails
