### PR TITLE
Update app/helpers/bootstrap_flash_helper.rb

### DIFF
--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -2,8 +2,9 @@ module BootstrapFlashHelper
   def bootstrap_flash
    flash_messages = []
    flash.each do |type, message|
-     # Skip Devise :timeout flag
+     # Skip Devise :timeout and :timedout flags
      next if type == :timeout
+     next if type == :timedout
      type = :success if type == :notice
      type = :error   if type == :alert
      text = content_tag(:div, 


### PR DESCRIPTION
Devise is sending "timedout" (timeDout) instead of "timeout".
This handle both cases.
