### PR TITLE
Allowing easier extension/change of Themed generator.

### DIFF
--- a/lib/generators/bootstrap/themed/themed_generator.rb
+++ b/lib/generators/bootstrap/themed/themed_generator.rb
@@ -10,6 +10,8 @@ module Bootstrap
       argument :layout,             :type => :string, :default => "application",
                                     :banner => "Specify application layout"
 
+      class_option :excluded_columns, :type => :array, :required => false
+
       def initialize(args, *options)
         super(args, *options)
         initialize_views_variables
@@ -53,16 +55,46 @@ module Bootstrap
       end
 
       def columns
-        excluded_column_names = %w[id created_at updated_at]
+        retrieve_columns.reject {|c| excluded?(c.name) }.map do |c|
+          new_attribute(c.name, c.type.to_s)
+        end
+      end
+
+      def excluded_columns_names
+        %w[id created_at updated_at]
+      end
+
+      def excluded_columns_pattern
+        [
+          /.*_checksum/,
+          /.*_count/,
+        ]
+      end
+
+      def excluded_columns
+        options['excluded_columns']||[]
+      end
+
+      def excluded?(name)
+        excluded_columns_names.include?(name) ||
+        excluded_columns_pattern.any? {|p| name =~ p } ||
+        excluded_columns.include?(name)
+      end
+
+      def retrieve_columns
         if defined?(ActiveRecord)
           rescue_block ActiveRecord::StatementInvalid do
-            @model_name.constantize.columns.reject{|c| excluded_column_names.include?(c.name) }.collect{|c| ::Rails::Generators::GeneratedAttribute.new(c.name, c.type)}
+            @model_name.constantize.columns
           end
         else
           rescue_block do
-            @model_name.constantize.fields.collect{|c| c[1]}.reject{|c| excluded_column_names.include?(c.name) }.collect{|c| ::Rails::Generators::GeneratedAttribute.new(c.name, c.type.to_s)}
+            @model_name.constantize.fields.map {|c| c[1] }
           end
         end
+      end
+
+      def new_attribute(name, type)
+        ::Rails::Generators::GeneratedAttribute.new(name, type)
       end
 
       def rescue_block(exception=Exception)


### PR DESCRIPTION
Hi, I just extracted to existing methods (columns and generate_views) into several methods so it's easier to extend. Now each method does only one thing, so it's easy to open the class and only change that, without. 

Also added the ability to exclude columns, and not only id, created_at or updated_at. 

I don't know, it might be useful. At least, it is for me. 

Thoughs? 

Lucas
