### PR TITLE
Making sure bootstrap_flash is in both layouts in all templates

### DIFF
--- a/lib/generators/bootstrap/layout/templates/layout.html.erb
+++ b/lib/generators/bootstrap/layout/templates/layout.html.erb
@@ -77,7 +77,8 @@
       <%- else -%>
         <div class="row">
           <div class="span9">
-             <%%= yield %>
+            <%%= bootstrap_flash %>
+            <%%= yield %>
           </div>
           <div class="span3">
             <div class="well sidebar-nav">

--- a/lib/generators/bootstrap/layout/templates/layout.html.haml
+++ b/lib/generators/bootstrap/layout/templates/layout.html.haml
@@ -44,6 +44,7 @@
               %li= link_to "Link 2", "/path2"
               %li= link_to "Link 3", "/path3"
         .span9
+          = bootstrap_flash
           = yield
     <% else %>
       .row

--- a/lib/generators/bootstrap/layout/templates/layout.html.slim
+++ b/lib/generators/bootstrap/layout/templates/layout.html.slim
@@ -44,6 +44,7 @@ html lang="en"
               li= link_to "Link 2", "/path2"
               li= link_to "Link 3", "/path3"
         .span9
+          = bootstrap_flash
           = yield
     <% else %>
       .row


### PR DESCRIPTION
Ran into this, and saw #369 already reported it.  Went ahead and made each template have the same content, looks like only the bootstrap_flash part on each template was inconsistent.
