### PR TITLE
Skip blank flash messages

### DIFF
--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -1,13 +1,15 @@
-module BootstrapFlashHelper  
+module BootstrapFlashHelper
   def bootstrap_flash
     flash_messages = []
     flash.each do |type, message|
       # Skip Devise :timeout and :timedout flags
       next if type == :timeout
       next if type == :timedout
+      # Skip empty messages, e.g. for devise messages set to nothing in a locale file.
+      next if message.blank?
       type = :success if type == :notice
       type = :error   if type == :alert
-      text = content_tag(:div, 
+      text = content_tag(:div,
                content_tag(:button, raw("&times;"), :class => "close", "data-dismiss" => "alert") +
                message, :class => "alert fade in alert-#{type}")
       flash_messages << text if message


### PR DESCRIPTION
Hi,

sometimes, to avoid an unwanted flash message, it can be necessary to set it to the empty string, instead of simply not setting it in the first place. A good example would be the standard Devise message "You must be logged in...", which I've always found redundant. It's easy to set this to empty in the locale file:

```
devise:
  failure:
    already_authenticated: 'You are already signed in.'
    unauthenticated: '' # don't display this
    unconfirmed: 'You have to confirm your account before continuing.'
```

These empty messages should be skipped completely - displaying the flash div without any message makes little sense.

Thanks!
