### PR TITLE
Generate multiple buttons for multiple errors.

### DIFF
--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -2,14 +2,17 @@ module BootstrapFlashHelper
   def bootstrap_flash
     flash_messages = []
     flash.each do |type, message|
-      # Skip empty messages, e.g. for devise messages set to nothing in a locale file.
-      next if message.blank?
+      # Skip Devise :timeout and :timedout flags
+      next if type == :timeout
+      next if type == :timedout
       type = :success if type == :notice
       type = :error   if type == :alert
-      text = content_tag(:div,
-               content_tag(:button, raw("&times;"), :class => "close", "data-dismiss" => "alert") +
-               message, :class => "alert fade in alert-#{type}")
-      flash_messages << text if message
+      Array(message).each do |msg|
+        text = content_tag(:div,
+                           content_tag(:button, raw("&times;"), :class => "close", "data-dismiss" => "alert") +
+                           msg, :class => "alert fade in alert-#{type}")
+        flash_messages << text if message
+      end
     end
     flash_messages.join("\n").html_safe
   end


### PR DESCRIPTION
If the flash contains an array of errors/notices/successes, this will 
display each of them in a separate button, instead of putting them all in 
one button.

The old behavior (if it only contains one thing) isn't changed.
