### PR TITLE
fix translation of helpers.links.confirm

### DIFF
--- a/lib/generators/bootstrap/install/templates/en.bootstrap.yml
+++ b/lib/generators/bootstrap/install/templates/en.bootstrap.yml
@@ -7,7 +7,7 @@ en:
     links:
       back: "Back"
       cancel: "Cancel"
-      confirm: "Confirm"
+      confirm: "Are you sure?"
       destroy: "Delete"
       new: "New"
     titles:


### PR DESCRIPTION
Because efault translation of confirm is 'Are you sure?', the translation of 'helpers.links.confirm' should be 'Are you sure?' instead of "Confirm".
