### PR TITLE
Show only alerts with supported types

### DIFF
--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -1,4 +1,6 @@
 module BootstrapFlashHelper
+  ALERT_TYPES = [:error, :info, :success, :warning]
+
   def bootstrap_flash
     flash_messages = []
     flash.each do |type, message|
@@ -7,6 +9,8 @@ module BootstrapFlashHelper
       
       type = :success if type == :notice
       type = :error   if type == :alert
+      next unless ALERT_TYPES.include?(type)
+
       Array(message).each do |msg|
         text = content_tag(:div,
                            content_tag(:button, raw("&times;"), :class => "close", "data-dismiss" => "alert") +


### PR DESCRIPTION
Flash messages are not something, that should always be displayed as an alert.

Flash can be used to store some service values or states and it's not expected behavior to show that values as alerts.
For example, if I want to render some form with default values from another action, I could use flash to store that values.
