### PR TITLE
ActiveRecord is a module, not a class.

### DIFF
--- a/lib/generators/bootstrap/themed/themed_generator.rb
+++ b/lib/generators/bootstrap/themed/themed_generator.rb
@@ -82,7 +82,7 @@ module Bootstrap
       end
 
       def retrieve_columns
-        if defined?(ActiveRecord) == "constant" && ActiveRecord.class == Class 
+        if defined?(ActiveRecord) == "constant" && ActiveRecord.class == Module 
           rescue_block ActiveRecord::StatementInvalid do
             @model_name.constantize.columns
           end


### PR DESCRIPTION
ActiveRecord is a module, not a class.

Update lib/generators/bootstrap/themed/themed_generator.rb
