### PR TITLE
Missing edit in localization sample

### DIFF
--- a/lib/generators/bootstrap/install/templates/en.bootstrap.yml
+++ b/lib/generators/bootstrap/install/templates/en.bootstrap.yml
@@ -10,6 +10,7 @@ en:
       confirm: "Are you sure?"
       destroy: "Delete"
       new: "New"
+      edit: "Edit"
     titles:
       edit: "Edit"
       save: "Save"


### PR DESCRIPTION
Was just running through a localization to spanish using the generators and noticed this when I copied over the template.
