### PR TITLE
Change JS manifest to application.js

### DIFF
--- a/lib/generators/bootstrap/install/install_generator.rb
+++ b/lib/generators/bootstrap/install/install_generator.rb
@@ -10,7 +10,7 @@ module Bootstrap
 
       def add_assets
 
-        js_manifest = 'app/assets/javascripts/applications.js'
+        js_manifest = 'app/assets/javascripts/application.js'
 
         if File.exist?(js_manifest)
           insert_into_file js_manifest, "//= require twitter/bootstrap\n", :after => "jquery_ujs\n"


### PR DESCRIPTION
Not sure if the naming was intentional to prevent overwriting existing files, but when the generator is run it creates a 'applications.js' file instead of an 'application.js' file. After running the generator, two JS manifest files are created which causes a asset pipeline error since one of them automatically includes the other.

I am not well versed in adding changes to projects, but I didn't just want to open an issue without at least attempting to correct it. Hopefully this was the right file to change and the right way to change it!
