### PR TITLE
render_breadcrumbs now accepts a &block argument

### DIFF
--- a/app/helpers/twitter_breadcrumbs_helper.rb
+++ b/app/helpers/twitter_breadcrumbs_helper.rb
@@ -1,5 +1,10 @@
 module TwitterBreadcrumbsHelper
-  def render_breadcrumbs(divider = '/')
-    render :partial => 'twitter-bootstrap/breadcrumbs', :locals => { :divider => divider }
+  def render_breadcrumbs(divider = '/', &block)
+    content = render :partial => 'twitter-bootstrap/breadcrumbs', :layout => false, :locals => { :divider => divider }
+    if block_given?
+      capture(content, &block)
+    else
+      content
+    end
   end
 end


### PR DESCRIPTION
This allows developers to customize how the breadcrumbs are rendered.

ex:

``` haml
= render_breadcrumbs do |breadcrumbs|
  .container
    = breadcrumbs
```

This way, the container wrapper will only appear if there are breadcrumbs. Otherwise, if you did this:

``` haml
.container
  = render_breadcrumbs
```

The `container` div would always be rendered.
