### PR TITLE
use content_tag instead of strings

### DIFF
--- a/app/helpers/badge_label_helper.rb
+++ b/app/helpers/badge_label_helper.rb
@@ -11,7 +11,6 @@ module BadgeLabelHelper
   def badge_label(what, value, type = nil)
     klass = [what]
     klass << "#{what}-#{type}" if type.present?
-
-    %{<span class="#{klass.join(' ')}">#{value}</span>}.html_safe
+    content_tag :span, value, :class => "#{klass.join(' ')}"
   end
 end


### PR DESCRIPTION
Changed the badge/label helper to use content_tag instead of a string.
