### PR TITLE
Added support for blocks in menu_item, to be more inline with link_to's ...

### DIFF
--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -15,10 +15,12 @@ module NavbarHelper
     content_tag(:ul, :class => "nav #{pull_class}", &block)
   end
 
-  def menu_item(name, path="#", *args)
+  def menu_item(name=nil, path="#", *args, &block)
+    path = name || path if block_given?
     options = args.extract_options!
     content_tag :li, :class => is_active?(path) do
-      link_to name, path, options
+      name, path = path, options if block_given?
+      link_to name, path, options, &block
     end
   end
 

--- a/spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb
+++ b/spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb
@@ -101,6 +101,18 @@ describe NavbarHelper, :type => :helper do
       self.stub!("uri_state").and_return(:active)
       menu_item("Log out", "/users/sign_out", :class => "home_link", :method => :delete).should eql('<li class="active"><a href="/users/sign_out" class="home_link" data-method="delete" rel="nofollow">Log out</a></li>')
     end
+    it "should pass a block but no name if a block is present" do
+      self.stub!("current_page?").and_return(false)
+      menu_item("/"){content_tag("i", "", :class => "icon-home") + " Home"}.should eql('<li><a href="/"><i class="icon-home"></i> Home</a></li>')
+    end
+    it "should work with just a block" do
+      self.stub!("current_page?").and_return(false)
+      menu_item{ content_tag("i", "", :class => "icon-home") + " Home" }.should eql('<li><a href="#"><i class="icon-home"></i> Home</a></li>')
+    end
+    it "should return the link with class 'active' if on current page with a block" do
+      self.stub!("uri_state").and_return(:active)
+      menu_item("/"){ content_tag("i", "", :class => "icon-home") + " Home" }.should eql('<li class="active"><a href="/"><i class="icon-home"></i> Home</a></li>')
+    end
   end
 
   describe "drop_down" do


### PR DESCRIPTION
Added support for blocks in menu_item, to be more inline with link_to's capabilities.

This allows you to use blocks instead of the name parameter. For example:

```
# inside menu_group
<%= menu_item root_path do %>
  <i class="icon-home"></i> Home
<% end %>
# returns
<li><a href="/">
  <i class="icon-home"></i> Home
</a></li>

# with no url works,
<%= menu_item do %>
  <i class="icon-off></i> Off
<% end %>
# returns
<li><a href="#">
  <i class="icon-off"></i> Off
</a></li>
```
