### PR TITLE
Fixed responsive navbar

### DIFF
--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -155,7 +155,7 @@ module NavbarHelper
   end
 
   def responsive_div(&block)
-    content_tag(:div, :class => "nav-collapse", &block)
+    content_tag(:div, :class => "nav-collapse collapse", &block)
   end
 
   def is_active?(path)


### PR DESCRIPTION
Added `collapse` class to `responsive_div` to make it work properly with dropdown buttons. See **Responsive Navbar** markup example at http://twitter.github.io/bootstrap/components.html#navbar and [this](https://github.com/twitter/bootstrap/issues/5671#issuecomment-10259395)
