### PR TITLE
Updated post_install_message in Gemspec file

### DIFF
--- a/twitter-bootstrap-rails.gemspec
+++ b/twitter-bootstrap-rails.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |s|
   "Node.js\n\n" \
   "Apple JavaScriptCore - Included with Mac OS X\n\n" \
   "Microsoft Windows Script Host (JScript)\n\n" \
-  "**********************************************"
+  "**********************************************\n"
 end


### PR DESCRIPTION
Added one \n at the end of post_install_message in gemspec file, since cursor for next command appears just next to the end of the message.

Attached Screenshot.

![twitter_bootstrap_rails](https://f.cloud.github.com/assets/1220255/653805/200efa26-d4e3-11e2-865d-14887ac4d030.png)
