### PR TITLE
Add support for 'pull-left' and 'pull-right' in glyph helper

### DIFF
--- a/app/helpers/glyph_helper.rb
+++ b/app/helpers/glyph_helper.rb
@@ -4,9 +4,14 @@ module GlyphHelper
   # # => <i class="icon-share-alt"></i>
   # glyph(:lock, :white)
   # # => <i class="icon-lock icon-white"></i>
+  # glyph(:thumbs_up, :pull_left)
+  # # => <i class="icon-thumbs-up pull-left"></i>
 
   def glyph(*names)
-    content_tag :i, nil, :class => names.map{|name| "icon-#{name.to_s.gsub('_','-')}" }
+    names.map! { |name| name.to_s.gsub('_','-') }
+    names.map! do |name|
+      name =~ /pull-(?:left|right)/ ? name : "icon-#{name}"
+    end
+    content_tag :i, nil, :class => names
   end
 end
-


### PR DESCRIPTION
To support this example: http://fortawesome.github.io/Font-Awesome/examples/#bordered-pulled
