### PR TITLE
added model name to default en bootstrap titles

### DIFF
--- a/lib/generators/bootstrap/install/templates/en.bootstrap.yml
+++ b/lib/generators/bootstrap/install/templates/en.bootstrap.yml
@@ -12,7 +12,7 @@ en:
       new: "New"
       edit: "Edit"
     titles:
-      edit: "Edit"
-      save: "Save"
-      new: "New"
-      delete: "Delete"
+      edit: "Edit %{model}"
+      save: "Save %{model}"
+      new: "New %{model}"
+      delete: "Delete %{model}"


### PR DESCRIPTION
This is just adding the model name to the default scaffolding titles for New/Save/Edit/Delete, I was trying to match the default when a localization file is not present: https://github.com/seyhunak/twitter-bootstrap-rails/blob/master/lib/generators/bootstrap/themed/templates/new.html.erb#L3
