### PR TITLE
uri_state method should receives symbol as param

### DIFF
--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -73,10 +73,16 @@ module NavbarHelper
   #   # Assume we'r currently at blog/categories/test
   #   uri_state('/blog/categories/test')   # :active
   #   uri_state('/blog/categories')        # :chosen
+  #   uri_state(:blog_categories)          # :chosen, same as previous
+  #   uri_state([:blog, :categories])      # :chosen, same as previous
   #   uri_state('/blog/categories/test/3') # :inactive    
   def uri_state(uri)
     root_url = request.host_with_port + '/'
     root = uri == '/' || uri == root_url
+
+    if !uri.respond_to?(:start_with?)
+      uri = url_for(uri)
+    end
 
     request_uri = if uri.start_with?(root_url)
       request.url

--- a/spec/lib/twitter_bootstrap_rails/uri_state_spec.rb
+++ b/spec/lib/twitter_bootstrap_rails/uri_state_spec.rb
@@ -13,11 +13,13 @@ describe NavbarHelper, 'uri_state', type: :helper do
     subject.stub_chain("request.protocol").and_return("http://")
     subject.stub_chain("request.url").and_return("#{HOST}/a/b")
     subject.stub_chain("request.path").and_return('/a/b')    
+    subject.stub("url_for").and_return('/a/b')
   end
 
   it 'must return active state' do
     subject.uri_state('/a/b').should == :active
     subject.uri_state("#{HOST}/a/b").should == :active
+    subject.uri_state(:a_b).should == :active
   end
 
   it 'must return chosen state' do


### PR DESCRIPTION
now we can pass symbols as param, e.g.:
- `= menu_item 'Page Managment', :admin_pages`
- `= menu_item 'Page Managment, [:admin, :pages]`
