### PR TITLE
Fixes deprecation of #in? in navbar_helper.rb

### DIFF
--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -159,7 +159,7 @@ module NavbarHelper
   end
 
   def is_active?(path)
-    "active" if uri_state(path).in?(:active, :chosen)
+    "active" if uri_state(path).in?([:active, :chosen])
   end
 
   def name_and_caret(name)


### PR DESCRIPTION
Calling #in? with multiple arguments is deprecated, please pass in an object that responds to #include? instead
- passing in an array
