### PR TITLE
Avoid duplicate loading of JavaScript in Rails4

### DIFF
--- a/lib/generators/bootstrap/layout/templates/layout.html.erb
+++ b/lib/generators/bootstrap/layout/templates/layout.html.erb
@@ -33,6 +33,8 @@
     <!-- For all other devices -->
     <!-- Size should be 32 x 32 pixels -->
     <%%= favicon_link_tag 'favicon.ico', :rel => 'shortcut icon' %>
+
+    <%%= javascript_include_tag "application" %>
   </head>
   <body>
 
@@ -99,11 +101,6 @@
       </footer>
 
     </div> <!-- /container -->
-
-    <!-- Javascripts
-    ================================================== -->
-    <!-- Placed at the end of the document so the pages load faster -->
-    <%%= javascript_include_tag "application" %>
 
   </body>
 </html>

--- a/lib/generators/bootstrap/layout/templates/layout.html.haml
+++ b/lib/generators/bootstrap/layout/templates/layout.html.haml
@@ -15,6 +15,7 @@
     = favicon_link_tag 'apple-touch-icon-72x72-precomposed.png', :rel => 'apple-touch-icon-precomposed', :type => 'image/png', :sizes => '72x72'
     = favicon_link_tag 'apple-touch-icon-precomposed.png', :rel => 'apple-touch-icon-precomposed', :type => 'image/png'
     = favicon_link_tag 'favicon.ico', :rel => 'shortcut icon'
+    = javascript_include_tag "application"
 
 
   %body
@@ -62,8 +63,3 @@
     <% end %>
       %footer
         %p &copy; Company 2013
-    /
-      Javascripts
-      \==================================================
-    / Placed at the end of the document so the pages load faster
-    = javascript_include_tag "application"

--- a/lib/generators/bootstrap/layout/templates/layout.html.slim
+++ b/lib/generators/bootstrap/layout/templates/layout.html.slim
@@ -16,6 +16,7 @@ html lang="en"
     = favicon_link_tag 'apple-touch-icon-72x72-precomposed.png', :rel => 'apple-touch-icon-precomposed', :type => 'image/png', :sizes => '72x72'
     = favicon_link_tag 'apple-touch-icon-precomposed.png', :rel => 'apple-touch-icon-precomposed', :type => 'image/png'
     = favicon_link_tag 'favicon.ico', :rel => 'shortcut icon'
+    = javascript_include_tag "application"
 
 
 
@@ -64,8 +65,3 @@ html lang="en"
     <% end %>
       footer
         p &copy; Company 2013
-    /!
-      Javascripts
-      \==================================================
-    /! Placed at the end of the document so the pages load faster
-    = javascript_include_tag "application"


### PR DESCRIPTION
Layout template that is generated by the following command

```
rails g bootstrap:layout [LAYOUT_NAME] [*fixed or fluid]
```

includes `javascript_include_tag` in the body tag.

In rails4, turbolinks replace body contents instead of reload page,
so JavaScript loaded multiple times.

If target page has submit button with `data-confirm="Are You Sure?"`,
confirm dialog shown multiple times.
