### PR TITLE
Add danger class to BootstrapFlashHelper. Fixes #639

### DIFF
--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -1,5 +1,5 @@
 module BootstrapFlashHelper
-  ALERT_TYPES = [:error, :info, :success, :warning]
+  ALERT_TYPES = [:success, :info, :warning, :danger]
 
   def bootstrap_flash
     flash_messages = []
@@ -8,13 +8,19 @@ module BootstrapFlashHelper
       next if message.blank?
       
       type = :success if type == :notice
-      type = :error   if type == :alert
+      type = :danger  if type == :alert
+      type = :danger  if type == :error
       next unless ALERT_TYPES.include?(type)
 
       Array(message).each do |msg|
         text = content_tag(:div,
-                           content_tag(:button, raw("&times;"), :class => "close", "data-dismiss" => "alert") +
-                           msg.html_safe, :class => "alert fade in alert-#{type}")
+                            content_tag(:button, raw("&times;"), 
+                                       :class => "close", 
+                                       "data-dismiss" => "alert",
+                                       "aria-hidden" => "true",
+                                       "type" => "button") +
+                            msg.html_safe,
+                           :class => "alert fade in alert-#{type} alert-dismissable")
         flash_messages << text if msg
       end
     end


### PR DESCRIPTION
Bootstrap 3 renamed `alert-error` to `alert-danger`. See: http://getbootstrap.com/components/#alerts

This adds support for:

``` ruby
flash[:danger] = "oopsie daisy"
```

It retains support for `error` flash messages so this will continue to work:

``` ruby
flash[:error] = "oopsie daisy"
```

Also, this adds accessibility attributes to the `button` element.
