### PR TITLE
Enhanced NavbarHelper#uri_state to support :root option.  Used to indica...

### DIFF
--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -87,7 +87,7 @@ module NavbarHelper
 
     if !options[:method].nil? || !options["data-method"].nil?
       :inactive
-    elsif uri == request_uri
+    elsif uri == request_uri || (options[:root] && (request_uri == '/') || (request_uri == root_url))
       :active
     else
       if request_uri.start_with?(uri) and not(root)


### PR DESCRIPTION
...te which uri should be treated as the root.

This enhancement allows the correct menu item to be highlighted (i.e. be shown as "active") for Rails root route.

Example of my use case:
# In routes.rb

resources :widgets, :thingees, :foobars
root :to => "widgets#index"
# In application layout

<%= nav_bar fixed: :top, brand: "Test App", responsive: true, inverse: true, fluid: true do %>
  <%= menu_item "Widgets", widgets_path, root: true %>
  <%= menu_item "Thingees", thingees_path %>
  <%= menu_item "Foobars", foobars_path %>
<% end %>
# Note the use of the :root option on the first menu_item, to indicate that this menu item represents the root of the app.  Without this enhancement, twitter-bootstrap-rails doesn't have a way to know which of the 3 menu items should be highlighted when the page is navigated to via the root path.

Please consider accepting my pull request.  And please let me know if you have any questions about my use case.

Thanks,
Denis
