### PR TITLE
Add parenthesis to scope variable math correctly

### DIFF
--- a/vendor/toolkit/twitter/bootstrap/variables.less
+++ b/vendor/toolkit/twitter/bootstrap/variables.less
@@ -178,7 +178,7 @@
 // Navbar
 // -------------------------
 @navbarCollapseWidth:             979px;
-@navbarCollapseDesktopWidth:      @navbarCollapseWidth + 1;
+@navbarCollapseDesktopWidth:      (@navbarCollapseWidth + 1);
 
 @navbarHeight:                    40px;
 @navbarBackgroundHighlight:       #ffffff;


### PR DESCRIPTION
This is the same problem that twbs declined to fix upstream:
https://github.com/twbs/bootstrap/pull/8450

It raises an error when compressing assets because without the
parenthesizes, uses of @navbarCollapseDesktopWidth are evaluated
 as "@media (max-width: 979px + 1)" instead of "@media (max-width: 980px)"

When trying to compress assets through the Rails 3 asset pipeline, this actually passes through the sass parser, which causes error:

```
Invalid CSS after "...n-width:979px +": expected number or function, was " 1){.nav-collap..."
/Users/pmm21/.rvm/gems/jruby-1.7.3/gems/sass-3.1.15/lib/sass/scss/parser.rb:927:in `expected'
/Users/pmm21/.rvm/gems/jruby-1.7.3/gems/sass-3.1.15/lib/sass/scss/parser.rb:874:in `expected'
/Users/pmm21/.rvm/gems/jruby-1.7.3/gems/sass-3.1.15/lib/sass/scss/parser.rb:856:in `expr!'
/Users/pmm21/.rvm/gems/jruby-1.7.3/gems/sass-3.1.15/lib/sass/scss/parser.rb:736:in `term'
/Users/pmm21/.rvm/gems/jruby-1.7.3/gems/sass-3.1.15/lib/sass/scss/parser.rb:718:in `expr'
```

There are other examples of such math, but I wasn't sure you would want to fix this here (since it is not being fixed at the source), so I didn't go through to find them all.
