### PR TITLE
Add breadcrumbs divider option to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,7 @@ Add flash helper `<%= bootstrap_flash %>` to your layout (built-in with layout g
 You do not need to use these breadcrumb gems since this gem provides the same functionality out of the box without the additional dependency.
 
 Add breadcrumbs helper `<%= render_breadcrumbs %>` to your layout.
+You can also specify a divider for it like this: `<%= render_breadcrumbs('>') %>` (default divider is `/`).
 
 ```ruby
 class ApplicationController


### PR DESCRIPTION
Currently, there is an option to set up breadcrumbs divider. Unfortunately, it's not stated in the README.md.
This commit adds it to readme so that new users don't have to check gem sources to configure divider (some users like me would like this option, especially after transition from [breadcrumbs_on_rails](https://github.com/weppos/breadcrumbs_on_rails)).
