### PR TITLE
Change fixed navbar to static in generated layout

### DIFF
--- a/lib/generators/bootstrap/layout/templates/layout.html.erb
+++ b/lib/generators/bootstrap/layout/templates/layout.html.erb
@@ -38,7 +38,7 @@
   </head>
   <body>
 
-    <div class="navbar navbar-fixed-top">
+    <div class="navbar navbar-static-top">
       <div class="container">
         <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
           <span class="icon-bar"></span>

--- a/lib/generators/bootstrap/layout/templates/layout.html.haml
+++ b/lib/generators/bootstrap/layout/templates/layout.html.haml
@@ -19,7 +19,7 @@
 
 
   %body
-    .navbar.navbar-fixed-top
+    .navbar.navbar-static-top
       .container
         %button.navbar-toggle(type="button" data-toggle="collapse" data-target=".navbar-responsive-collapse")
           %span.icon-bar

--- a/lib/generators/bootstrap/layout/templates/layout.html.slim
+++ b/lib/generators/bootstrap/layout/templates/layout.html.slim
@@ -21,7 +21,7 @@ html lang="en"
 
 
   body
-    .navbar.navbar-fixed-top
+    .navbar.navbar-static-top
         .container
           button.navbar-toggle type="button" data-toggle="collapse" data-target=".navbar-responsive-collapse"
             span.icon-bar


### PR DESCRIPTION
There is a problem with class `navbar-fixed-top` in new generated layout, because navbar overlays other content. Bootstrap's [documentation](http://getbootstrap.com/components/#navbar-fixed-top) recommends to set a padding to body. 
Instead, I suggest to change the class to `navbar-static-top`.
