### PR TITLE
add quotes around class names to fix syntax errors

### DIFF
--- a/lib/generators/bootstrap/themed/templates/index.html.erb
+++ b/lib/generators/bootstrap/themed/templates/index.html.erb
@@ -23,7 +23,7 @@
         <td><%%=l <%= resource_name %>.created_at %></td>
         <td>
           <%%= link_to t('.edit', :default => t("helpers.links.edit")),
-                      edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => btn btn-default btn-xs %>
+                      edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs' %>
           <%%= link_to t('.destroy', :default => t("helpers.links.destroy")),
                       <%= singular_controller_routing_path %>_path(<%= resource_name %>),
                       :method => :delete,

--- a/lib/generators/bootstrap/themed/templates/index.html.haml
+++ b/lib/generators/bootstrap/themed/templates/index.html.haml
@@ -19,7 +19,7 @@
         <%- end -%>
         %td=l <%= resource_name %>.created_at
         %td
-          = link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => btn btn-default btn-xs
+          = link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs'
           = link_to t('.destroy', :default => t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-xs btn-danger'
 
 = link_to t('.new', :default => t("helpers.links.new")), new_<%= singular_controller_routing_path %>_path, :class => 'btn btn-primary'

--- a/lib/generators/bootstrap/themed/templates/index.html.slim
+++ b/lib/generators/bootstrap/themed/templates/index.html.slim
@@ -19,7 +19,7 @@ table class="table table-striped"
         <%- end -%>
         td=l <%= resource_name %>.created_at
         td
-          = link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => btn btn-default btn-xs
+          = link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs'
           '
           = link_to t('.destroy', :default => t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-xs btn-danger'
 


### PR DESCRIPTION
the missing quotes around the class names in the index template cause syntax errors.
