### PR TITLE
Updated glyph icon class names for bootstrap 3

### DIFF
--- a/app/helpers/glyph_helper.rb
+++ b/app/helpers/glyph_helper.rb
@@ -10,7 +10,7 @@ module GlyphHelper
   def glyph(*names)
     names.map! { |name| name.to_s.gsub('_','-') }
     names.map! do |name|
-      name =~ /pull-(?:left|right)/ ? name : "icon-#{name}"
+      name =~ /pull-(?:left|right)/ ? name : "glyphicon glyphicon-#{name}"
     end
     content_tag :i, nil, :class => names
   end


### PR DESCRIPTION
I have updated the glyph icon helper to load latest glyphicon classes (typo changes) compatible with Bootstrap 3.0
