### PR TITLE
Adds brand_html_left and brand_html_right options to NavBar helper.

### DIFF
--- a/app/assets/stylesheets/twitter-bootstrap-static/bootstrap.css.erb
+++ b/app/assets/stylesheets/twitter-bootstrap-static/bootstrap.css.erb
@@ -657,6 +657,8 @@ button.btn.btn-mini,input[type="submit"].btn.btn-mini{*padding-top:1px;*padding-
 .navbar .container{width:auto;}
 .nav-collapse.collapse{height:auto;overflow:visible;}
 .navbar .brand{float:left;display:block;padding:10px 20px 10px;margin-left:-20px;font-size:20px;font-weight:200;color:#777777;text-shadow:0 1px 0 #ffffff;}.navbar .brand:hover,.navbar .brand:focus{text-decoration:none;}
+.navbar .brand_html_left{float:left;display:block;}
+.navbar .brand_html_right{float:left;display:block;margin-left:-5px;}
 .navbar-text{margin-bottom:0;line-height:40px;color:#777777;}
 .navbar-link{color:#777777;}.navbar-link:hover,.navbar-link:focus{color:#333333;}
 .navbar .divider-vertical{height:40px;margin:0 9px;border-left:1px solid #f2f2f2;border-right:1px solid #ffffff;}

--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -3,7 +3,7 @@ module NavbarHelper
   def nav_bar(options={}, &block)
     nav_bar_div(options) do
       navbar_inner_div do
-        container_div(options[:brand], options[:brand_link], options[:responsive], options[:fluid]) do
+        container_div(options[:brand], options[:brand_link], options[:brand_html_left], options[:brand_html_right], options[:responsive], options[:fluid]) do
           yield if block_given?
         end
       end
@@ -117,20 +117,20 @@ module NavbarHelper
     end
   end
 
-  def container_div(brand, brand_link, responsive, fluid, &block)
+  def container_div(brand, brand_link, brand_html_left, brand_html_right, responsive, fluid, &block)
     content_tag :div, :class => "container#{"-fluid" if fluid}" do
-      container_div_with_block(brand, brand_link, responsive, &block)
+      container_div_with_block(brand, brand_link, brand_html_left, brand_html_right, responsive, &block)
     end
   end
 
-  def container_div_with_block(brand, brand_link, responsive, &block)
+  def container_div_with_block(brand, brand_link, brand_html_left, brand_html_right, responsive, &block)
     output = []
     if responsive == true
       output << responsive_button
-      output << brand_link(brand, brand_link)
+      output << brand_link(brand, brand_link, brand_html_left, brand_html_right)
       output << responsive_div { capture(&block) }
     else
-      output << brand_link(brand, brand_link)
+      output << brand_link(brand, brand_link, brand_html_left, brand_html_right)
       output << capture(&block)
     end
     output.join("\n").html_safe
@@ -143,10 +143,15 @@ module NavbarHelper
     css_class.join(" ")
   end
 
-  def brand_link(name, url)
+  def brand_link(name, url, brand_html_left, brand_html_right)
     return "" if name.blank?
     url ||= root_url
-    link_to(name, url, :class => "brand")
+
+    output = []
+    output << '<div class="brand_html_left">' + brand_html_left + '</div>' if brand_html_left
+    output << link_to(name, url, :class => "brand")
+    output << '<div class="brand_html_right">' + brand_html_right + '</div>' if brand_html_right
+    output.join("\n").html_safe
   end
 
   def responsive_button


### PR DESCRIPTION
Enables the user to pass in optional html to appear before or after the brand.

![brand_html_right](https://f.cloud.github.com/assets/1134807/1647793/f889649c-5952-11e3-9abf-8af6b35e8b33.png)
![brand_html_right_collapsed](https://f.cloud.github.com/assets/1134807/1647813/ff36994e-5953-11e3-85be-2572f10a6e7f.png)

A similar result can't be achieved in the nav_bar block because all of that gets wrapped into the "nav-collapsed collapsed" div, where it breaks away from the brand when collapsed.
