### PR TITLE
changed 'asset-url' to 'font-url' in bootstrap_and_css_overides.less thi...

### DIFF
--- a/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
+++ b/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
@@ -6,11 +6,11 @@
 @iconWhiteSpritePath: image-url("twitter/bootstrap/glyphicons-halflings-white.png");
 
 // Set the Font Awesome (Font Awesome is default. You can disable by commenting below lines)
-@fontAwesomeEotPath: asset-url("fontawesome-webfont.eot");
-@fontAwesomeEotPath_iefix: asset-url("fontawesome-webfont.eot?#iefix");
-@fontAwesomeWoffPath: asset-url("fontawesome-webfont.woff");
-@fontAwesomeTtfPath: asset-url("fontawesome-webfont.ttf");
-@fontAwesomeSvgPath: asset-url("fontawesome-webfont.svg#fontawesomeregular");
+@fontAwesomeEotPath: font-url("fontawesome-webfont.eot");
+@fontAwesomeEotPath_iefix: font-url("fontawesome-webfont.eot?#iefix");
+@fontAwesomeWoffPath: font-url("fontawesome-webfont.woff");
+@fontAwesomeTtfPath: font-url("fontawesome-webfont.ttf");
+@fontAwesomeSvgPath: font-url("fontawesome-webfont.svg#fontawesomeregular");
 
 // Font Awesome
 @import "fontawesome/font-awesome";


### PR DESCRIPTION
changed 'asset-url' to 'font-url' in bootstrap_and_css_overides.less this fixes an issue I was having in rails 4.0.2 where the asset digest was not included in the resource url
