### PR TITLE
use asset-url so that things don't break when we precompile assets

### DIFF
--- a/vendor/toolkit/twitter/bootstrap/glyphicons.less
+++ b/vendor/toolkit/twitter/bootstrap/glyphicons.less
@@ -10,11 +10,11 @@
 // Import the fonts
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: ~"url('@{icon-font-name}.eot')";
-  src: ~"url('@{icon-font-name}.eot?#iefix') format('embedded-opentype')",
-       ~"url('@{icon-font-name}.woff') format('woff')",
-       ~"url('@{icon-font-name}.ttf') format('truetype')",
-       ~"url('@{icon-font-name}.svg#@{icon-font-svg-id}') format('svg')";
+  src: asset-url('@{icon-font-name}.eot');
+  src: asset-url('@{icon-font-name}.eot?#iefix') format('embedded-opentype'),
+       asset-url('@{icon-font-name}.woff') format('woff'),
+       asset-url('@{icon-font-name}.ttf') format('truetype'),
+       asset-url('@{icon-font-name}.svg#glyphicons-halflingsregular') format('svg');
 }
 
 // Catchall baseclass


### PR DESCRIPTION
Per some comments in my last pull request, I've made a change to use an asset-pipeline-friendly function call
