### PR TITLE
Make bootstrap_flash work with Rails 4.1.0.rc1

### DIFF
--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -6,7 +6,8 @@ module BootstrapFlashHelper
     flash.each do |type, message|
       # Skip empty messages, e.g. for devise messages set to nothing in a locale file.
       next if message.blank?
-      
+
+      type = type.to_sym
       type = :success if type == :notice
       type = :error   if type == :alert
       next unless ALERT_TYPES.include?(type)


### PR DESCRIPTION
Flash types are strings in [Rails 4.1.0.rc1](https://github.com/rails/rails/commit/a6ce984b49519de7701aa13d04300c9d03cf8f72). The current code expects types to be symbols and doesn't work with string types.
