### PR TITLE
let nav_bar method support full screen fluid view

### DIFF
--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -110,7 +110,8 @@ module NavbarHelper
   end
 
   def container_div(brand, brand_link, responsive, fluid, &block)
-    content_tag :div, :class => "container" do
+    div_container_class = fluid ? "container-fluid" : "container"
+    content_tag :div, :class => div_container_class do
       container_div_with_block(brand, brand_link, responsive, &block)
     end
   end


### PR DESCRIPTION
The little change let the nav_bar method supports full screen fluid view. After this update, you can set the `:fluid` option to `true`, this will set the class of container div to be "container-fluid'.

```
<%= nav_bar :fluid => true  %>
```

will render

```
<div class="navbar">
  <div class="container-fluid">
  </div>
</div>
```
