### PR TITLE
delete the # otherwise rails  assets pipeline will generate url

### DIFF
--- a/app/assets/stylesheets/twitter-bootstrap-static/bootstrap.css.erb
+++ b/app/assets/stylesheets/twitter-bootstrap-static/bootstrap.css.erb
@@ -5782,4 +5782,4 @@ button.close {
     display: none !important;
   }
 }
-/*# sourceMappingURL=bootstrap.css.map */
+/* sourceMappingURL=bootstrap.css.map */


### PR DESCRIPTION
delete the # otherwise rails  assets pipeline will generate url like below:

```
ActionController::RoutingError (No route matches [GET] "/assets/twitter-bootstrap-  static/bootstrap.css.map"):
  actionpack (4.0.4) lib/action_dispatch/middleware/debug_exceptions.rb:21:in `call'
```
