### PR TITLE
Fix incorrectly named navbar-collapse class

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ Which renders the html quite differently:
           <span class="icon-bar"></span>
         </button>
         <!-- Everything in here gets hidden at 940px or less -->
-        <div class="nav-collapse collapse">
+        <div class="navbar-collapse collapse">
           <!-- menu items gets rendered here instead -->
         </div>
       </div>

--- a/lib/generators/bootstrap/layout/templates/layout.html.erb
+++ b/lib/generators/bootstrap/layout/templates/layout.html.erb
@@ -46,7 +46,7 @@
           <span class="icon-bar"></span>
         </button>
         <a class="navbar-brand" href="#"><%= app_name %></a>
-        <div class="nav-collapse collapse navbar-responsive-collapse">
+        <div class="navbar-collapse collapse navbar-responsive-collapse">
           <ul class="nav navbar-nav">
             <li><%%= link_to "Link1", "/path1"  %></li>
             <li><%%= link_to "Link2", "/path2"  %></li>

--- a/lib/generators/bootstrap/layout/templates/layout.html.haml
+++ b/lib/generators/bootstrap/layout/templates/layout.html.haml
@@ -26,7 +26,7 @@
           %span.icon-bar
           %span.icon-bar
         %a.navbar-brand(href="#") <%= app_name %>
-        .nav-collapse.collapse.navbar-responsive-collapse
+        .navbar-collapse.collapse.navbar-responsive-collapse
           %ul.nav.navbar-nav
             %li= link_to "Link 1", "/path1"
             %li= link_to "Link 2", "/path2"

--- a/lib/generators/bootstrap/layout/templates/layout.html.slim
+++ b/lib/generators/bootstrap/layout/templates/layout.html.slim
@@ -28,7 +28,7 @@ html lang="en"
             span.icon-bar
             span.icon-bar
           a.navbar-brand href="#"<%= app_name %>
-          .nav-collapse.collapse.navbar-responsive-collapse
+          .navbar-collapse.collapse.navbar-responsive-collapse
             ul.nav.navbar-nav
               li= link_to "Link 1", "/path1"
               li= link_to "Link 2", "/path2"


### PR DESCRIPTION
I'm thinking `nav-collapse` might have been the class in Bootstrap 2? [Bootstrap 3 now uses `navbar-collapse`](https://github.com/seyhunak/twitter-bootstrap-rails/blob/bdd3063d5db19057b843cd4b8c0c6f71697b385d/vendor/assets/stylesheets/twitter-bootstrap-static/bootstrap.css.erb#L3658).

This fixes the bug where the navbar isn't visible when collapsed.
