### PR TITLE
Fixed for Rails 4.1 and Ruby 2.1

### DIFF
--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -8,8 +8,8 @@ module BootstrapFlashHelper
       next if message.blank?
 
       type = type.to_sym
-      type = :success if type == :notice
-      type = :error   if type == :alert
+      type = :success if type.to_s == :notice.to_s
+      type = :error   if type.to_s == :alert.to_s
       next unless ALERT_TYPES.include?(type)
 
       Array(message).each do |msg|


### PR DESCRIPTION
I use Rails 4.1 and Ruby 2.1. In each's block 'type' is String, but if in another verion RoR or Ruby 'type' is Symbol then convert 'type' to String in both.
