### PR TITLE
fix Empty string passed to getElementById().

### DIFF
--- a/app/assets/javascripts/twitter/bootstrap/bootstrap-dropdown.js
+++ b/app/assets/javascripts/twitter/bootstrap/bootstrap-dropdown.js
@@ -123,7 +123,11 @@
       selector = selector && /#/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
     }
 
-    $parent = selector && $(selector)
+    if (selector === "#"){
+      $parent = $("")
+    } else {
+      $parent = selector && $(selector)
+    }
 
     if (!$parent || !$parent.length) $parent = $this.parent()
 


### PR DESCRIPTION
according to:
https://github.com/shishirmk/bootstrap/commit/ecf0605f7a3d8406f2a06acd6250d146ecfb9592

this will fix the Empty string passed to getElementById(). in FireFox
