### PR TITLE
Fix error 'no implicit conversion of Symbol into Integer'

### DIFF
--- a/app/helpers/glyph_helper.rb
+++ b/app/helpers/glyph_helper.rb
@@ -8,7 +8,8 @@ module GlyphHelper
   # # => <i class="icon-thumbs-up pull-left"></i>
   # glyph(:lock, {tag: :span})
   # # => <span class="icon-lock"></span>
-  def glyph(*names, options)
+  def glyph(*names)
+    options = (names.last.kind_of?(Hash)) ? names.pop : {}
     names.map! { |name| name.to_s.gsub('_','-') }
     names.map! do |name|
       name =~ /pull-(?:left|right)/ ? name : "glyphicon glyphicon-#{name}"


### PR DESCRIPTION
`glyph(:pencil)` raises error `no implicit conversion of Symbol into Integer`.
This commit fixes the error.
