### PR TITLE
Fix modal_dialog

### DIFF
--- a/app/helpers/modal_helper.rb
+++ b/app/helpers/modal_helper.rb
@@ -10,9 +10,9 @@ module ModalHelper
     content_tag :div, :id => options[:id], :class => "bootstrap-modal modal fade" do
       content_tag :div, :class => "modal-dialog #{opts['size']}" do
         content_tag :div, :class => "modal-content" do
-          modal_header(opts, &block) +
-          modal_body(opts, &block) +
-          modal_footer(opts, &block) 
+          modal_header(options[:header], &block) +
+          modal_body(options[:body], &block) +
+          modal_footer(options[:footer], &block)
         end
       end
     end

--- a/spec/lib/twitter_bootstrap_rails/modal_helper_spec.rb
+++ b/spec/lib/twitter_bootstrap_rails/modal_helper_spec.rb
@@ -41,7 +41,7 @@ describe ModalHelper, :type => :helper do
 end
 
 BASIC_MODAL = <<-HTML
-<div class=\"bootstrap-modal modal fade\" id=\"modal\"><div class=\"modal-dialog \"><div class=\"modal-content\"><div class=\"modal-header\"><button class=\"close\" data-dismiss=\"true\" aria-hidden=\"true\">&times;</button><h4 class=\"modal-title\"></h4></div><div class=\"modal-body\"></div><div class=\"modal-footer\"></div></div></div></div>
+<div class=\"bootstrap-modal modal fade\" id=\"modal\"><div class=\"modal-dialog \"><div class=\"modal-content\"><div class=\"modal-header\"><button class=\"close\" data-dismiss=\"modal\" aria-hidden=\"true\">&times;</button><h4 class=\"modal-title\">Modal header</h4></div><div class=\"modal-body\">This is the body</div><div class=\"modal-footer\"><button class="btn">Save</button></div></div></div></div>
 HTML
 
 MODAL_HEADER_WITHOUT_CLOSE = <<-HTML


### PR DESCRIPTION
An empty dialog is displayed, as shown in the following example.

```
<%= content_tag :a, "Modal", :href => "#modal", :class => 'btn', :data => {:toggle => 'modal'} %>

<%= modal_dialog :id => "modal",
         :header => { :show_close => true, :dismiss => 'modal', :title => 'Modal header' },
         :body   => { :content => 'This is the body' },
         :footer => { :content => content_tag(:button, 'Save', :class => 'btn') } %>
```
