### PR TITLE
add type attribute to button for bootstrap flashes

### DIFF
--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -15,7 +15,7 @@ module BootstrapFlashHelper
 
       Array(message).each do |msg|
         text = content_tag(:div,
-                           content_tag(:button, raw("&times;"),:type => "button", :class => "close", "data-dismiss" => "alert") +
+                           content_tag(:button, raw("&times;"), :type => "button", :class => "close", "data-dismiss" => "alert") +
                            msg, :class => "alert fade in alert-#{type} #{options[:class]}")
         flash_messages << text if msg
       end


### PR DESCRIPTION
According to [bootlint](https://github.com/twbs/bootlint) all buttons should have a type shown [here](https://github.com/twbs/bootlint/blob/master/src/bootlint.js#L451-L456)

This pull request adds the default `type="button"` to the BootstrapFlashHelper.

References:
http://wtfhtmlcss.com/#buttons-type
