### PR TITLE
Removed rails dependency

### DIFF
--- a/twitter-bootstrap-rails.gemspec
+++ b/twitter-bootstrap-rails.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency             'railties',   '>= 3.1'
   s.add_dependency             'actionpack', '>= 3.1'
   s.add_runtime_dependency 'execjs'
-  s.add_runtime_dependency 'rails', '>= 3.1'
   s.add_development_dependency 'less'
   s.add_development_dependency 'therubyracer'
   s.post_install_message = "Important: You may need to add a javascript runtime to your Gemfile in order for bootstrap's LESS files to compile to CSS. \n\n" \


### PR DESCRIPTION
Rails depends on activerecord which is not needed for every project. It
is also not needed for twitter-bootstrap-rails to work. The gem already
depends on actionpack which should be enough.