### PR TITLE
Slim-ify the .slim templates

### DIFF
--- a/lib/generators/bootstrap/themed/templates/edit.html.slim
+++ b/lib/generators/bootstrap/themed/templates/edit.html.slim
@@ -1,4 +1,4 @@
 - model_class = <%= resource_name.classify %>
-div class="page-header"
+.page-header
   h1=t '.title', :default => [:'helpers.titles.edit', 'Edit %{model}'], :model => model_class.model_name.human.titleize
 = render :partial => "form"

--- a/lib/generators/bootstrap/themed/templates/index.html.slim
+++ b/lib/generators/bootstrap/themed/templates/index.html.slim
@@ -1,7 +1,7 @@
 - model_class = <%= resource_name.classify %>
-div class="page-header"
+.page-header
   h1=t '.title', :default => model_class.model_name.human.pluralize.titleize
-table class="table table-striped"
+table.table.table-striped
   thead
     tr
       th= model_class.human_attribute_name(:id)
@@ -24,4 +24,3 @@ table class="table table-striped"
           = link_to t('.destroy', :default => t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-xs btn-danger'
 
 = link_to t('.new', :default => t("helpers.links.new")), new_<%= singular_controller_routing_path %>_path, :class => 'btn btn-primary'
-

--- a/lib/generators/bootstrap/themed/templates/new.html.slim
+++ b/lib/generators/bootstrap/themed/templates/new.html.slim
@@ -1,4 +1,4 @@
 - model_class = <%= resource_name.classify %>
-div class="page-header"
+.page-header
   h1=t '.title', :default => [:'helpers.titles.new', 'New %{model}'], :model => model_class.model_name.human.titleize
 = render :partial => "form"

--- a/lib/generators/bootstrap/themed/templates/show.html.slim
+++ b/lib/generators/bootstrap/themed/templates/show.html.slim
@@ -1,5 +1,5 @@
 - model_class = <%= resource_name.classify %>
-div class="page-header"
+.page-header
   h1=t '.title', :default => model_class.model_name.human.titleize
 
 <%- columns.each do |column| -%>


### PR DESCRIPTION
Remove unnecessary `class=` and `div`s from the `.slim` templates
