### PR TITLE
Use merged_options variable

### DIFF
--- a/app/helpers/twitter_breadcrumbs_helper.rb
+++ b/app/helpers/twitter_breadcrumbs_helper.rb
@@ -1,7 +1,7 @@
 module TwitterBreadcrumbsHelper
   def render_breadcrumbs(divider = '/', options={}, &block)
-    default_options = { :class => '', :item_class => '', :divider_class => '', :active_class => 'active' }.merge(options)
-    content = render :partial => 'twitter-bootstrap/breadcrumbs', :layout => false, :locals => { :divider => divider, options: options }
+    merged_options = { :class => '', :item_class => '', :divider_class => '', :active_class => 'active' }.merge(options)
+    content = render :partial => 'twitter-bootstrap/breadcrumbs', :layout => false, :locals => { :divider => divider, options: merged_options }
     if block_given?
       capture(content, &block)
     else


### PR DESCRIPTION
Looks like the default_options hash was never actually used, I've corrected it and changed the name to merged_options to better describe the content of the hash.