### PR TITLE
Fix issue with missing Fontawesome icons when using Less template

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,12 +207,13 @@ This should appear inside _bootstrap_and_overrides *(based on you twitter-bootst
 
 ```css
 // Font Awesome
-@fontAwesomeEotPath: asset-url("fontawesome-webfont.eot");
-@fontAwesomeEotPath_iefix: asset-url("fontawesome-webfont.eot?#iefix");
-@fontAwesomeWoffPath: asset-url("fontawesome-webfont.woff");
-@fontAwesomeTtfPath: asset-url("fontawesome-webfont.ttf");
-@fontAwesomeSvgPath: asset-url("fontawesome-webfont.svg#fontawesomeregular");
+@fontAwesomeEotPath: font-url("fontawesome-webfont.eot");
+@fontAwesomeEotPath_iefix: font-url("fontawesome-webfont.eot?#iefix");
+@fontAwesomeWoffPath: font-url("fontawesome-webfont.woff");
+@fontAwesomeTtfPath: font-url("fontawesome-webfont.ttf");
+@fontAwesomeSvgPath: font-url("fontawesome-webfont.svg#fontawesomeregular");
 @import "fontawesome/font-awesome";
+@fa-font-path: "/assets";
 ```
 
 **Before 2.2.7**

--- a/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
+++ b/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
@@ -16,7 +16,7 @@
 
 // Font Awesome
 @import "fontawesome/font-awesome";
-@fa-font-path: "/assets"; // Override fontawesome less variable in order for it to work with Rails asset pipeline 
+@fa-font-path: "/assets"; // Overwrite fontawesome less variable in order for it to work with Rails asset pipeline 
 
 // Glyphicons
 //@import "twitter/bootstrap/glyphicons.less";

--- a/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
+++ b/lib/generators/bootstrap/install/templates/bootstrap_and_overrides.less
@@ -16,6 +16,7 @@
 
 // Font Awesome
 @import "fontawesome/font-awesome";
+@fa-font-path: "/assets"; // Override fontawesome less variable in order for it to work with Rails asset pipeline 
 
 // Glyphicons
 //@import "twitter/bootstrap/glyphicons.less";

--- a/lib/twitter/bootstrap/rails/version.rb
+++ b/lib/twitter/bootstrap/rails/version.rb
@@ -1,7 +1,7 @@
 module Twitter
   module Bootstrap
     module Rails
-      VERSION = "3.2.1"
+      VERSION = "3.2.2"
     end
   end
 end


### PR DESCRIPTION
When using less templates, the font path used in `fontawesome/variables.less` does not work with Rails asset pipeline. By overwriting the `@fa-font-path` used in the [Font Awesome toolkit](https://github.com/FortAwesome/Font-Awesome), it now works. 