### PR TITLE
Colon missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ It should let you write things like:
         <% if current_user %>
             <%= menu_item "Log Out", log_out_path %>
         <% else %>
-            <%= form_for @user, url: session_path(:user), html => {class: "navbar-form pull-right"} do |f| -%>
+            <%= form_for @user, url: session_path(:user), :html => {class: "navbar-form pull-right"} do |f| -%>
               <p><%= f.text_field :email %></p>
               <p><%= f.password_field :password %></p>
               <p><%= f.submit "Sign in" %></p>


### PR DESCRIPTION
It was missing a colon before html attribute called at form_for of nav_bar.
