### PR TITLE
fix rspec failed tests

### DIFF
--- a/app/helpers/modal_helper.rb
+++ b/app/helpers/modal_helper.rb
@@ -7,7 +7,7 @@ module ModalHelper
   #modals have a header, a body, a footer for options.
   def modal_dialog(options = {}, &block)
     opts = default_options.merge(options)
-    content_tag :div, :id => options[:id], :class => "bootstrap-modal modal fade" do
+    content_tag :div, :class => "bootstrap-modal modal fade", :id => options[:id] do
       content_tag :div, :class => "modal-dialog #{opts['size']}" do
         content_tag :div, :class => "modal-content" do
           modal_header(options[:header], &block) +

--- a/spec/lib/twitter_bootstrap_rails/modal_helper_spec.rb
+++ b/spec/lib/twitter_bootstrap_rails/modal_helper_spec.rb
@@ -36,7 +36,7 @@ describe ModalHelper, :type => :helper do
   end
 
   it 'renders a cancel button' do
-    expect(modal_cancel_button("Cancel", :href => "#modal", :data => {:dismiss => 'modal'}).gsub(/\n/, "")).to eql MODAL_CANCEL_BUTTON.gsub(/\n/, "")
+    expect(modal_cancel_button("Cancel", :data => {:dismiss => 'modal'}, :href => "#modal").gsub(/\n/, "")).to eql MODAL_CANCEL_BUTTON.gsub(/\n/, "")
   end
 end
 

--- a/spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb
+++ b/spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb
@@ -107,7 +107,7 @@ describe NavbarHelper, :type => :helper do
     end
     it "should pass any other options through to the link_to method" do
       allow(self).to receive_message_chain("uri_state").and_return(:active)
-      expect(menu_item("Log out", "/users/sign_out", :class => "home_link", :method => :delete)).to eql('<li class="active"><a class="home_link" data-method="delete" href="/users/sign_out" rel="nofollow">Log out</a></li>')
+      expect(menu_item("Log out", "/users/sign_out", :class => "home_link", :method => :delete)).to eql('<li class="active"><a class="home_link" rel="nofollow" data-method="delete" href="/users/sign_out">Log out</a></li>')
     end
     it "should pass a block but no name if a block is present" do
       allow(self).to receive(:current_page?) { false }


### PR DESCRIPTION
Hello , bootstrap fans!
When I run rspec on current master I have the following errors, so fix it changing disposition of html attributes in elements(which is not important in real practice)

``` ruby
twitter-bootstrap-rails$ rspec 
.............F....F...............F.................

Failures:

  1) ModalHelper returns a complete modal
     Failure/Error: expect(modal_dialog(options).gsub(/\n/, "")).to eql BASIC_MODAL.gsub(/\n/, "")

       expected: "<div class=\"bootstrap-modal modal fade\" id=\"modal\"><div class=\"modal-dialog \"><div class=\"modal-content\"><div class=\"modal-header\"><button class=\"close\" data-dismiss=\"modal\" aria-hidden=\"true\">&times;</button><h4 class=\"modal-title\">Modal header</h4></div><div class=\"modal-body\">This is the body</div><div class=\"modal-footer\"><button class=\"btn\">Save</button></div></div></div></div>"
            got: "<div id=\"modal\" class=\"bootstrap-modal modal fade\"><div class=\"modal-dialog \"><div class=\"modal-content\"><div class=\"modal-header\"><button class=\"close\" data-dismiss=\"modal\" aria-hidden=\"true\">&times;</button><h4 class=\"modal-title\">Modal header</h4></div><div class=\"modal-body\">This is the body</div><div class=\"modal-footer\"><button class=\"btn\">Save</button></div></div></div></div>"

       (compared using eql?)
     # ./spec/lib/twitter_bootstrap_rails/modal_helper_spec.rb:19:in `block (2 levels) in <top (required)>'

  2) ModalHelper renders a cancel button
     Failure/Error: expect(modal_cancel_button("Cancel", :href => "#modal", :data => {:dismiss => 'modal'}).gsub(/\n/, "")).to eql MODAL_CANCEL_BUTTON.gsub(/\n/, "")

       expected: "<a class=\"btn bootstrap-modal-cancel-button\" data-dismiss=\"modal\" href=\"#modal\">Cancel</a>"
            got: "<a class=\"btn bootstrap-modal-cancel-button\" href=\"#modal\" data-dismiss=\"modal\">Cancel</a>"

       (compared using eql?)
     # ./spec/lib/twitter_bootstrap_rails/modal_helper_spec.rb:39:in `block (2 levels) in <top (required)>'

  3) NavbarHelper menu_item should pass any other options through to the link_to method
     Failure/Error: expect(menu_item("Log out", "/users/sign_out", :class => "home_link", :method => :delete)).to eql('<li class="active"><a class="home_link" data-method="delete" href="/users/sign_out" rel="nofollow">Log out</a></li>')

       expected: "<li class=\"active\"><a class=\"home_link\" data-method=\"delete\" href=\"/users/sign_out\" rel=\"nofollow\">Log out</a></li>"
            got: "<li class=\"active\"><a class=\"home_link\" rel=\"nofollow\" data-method=\"delete\" href=\"/users/sign_out\">Log out</a></li>"

       (compared using eql?)
     # ./spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb:110:in `block (3 levels) in <top (required)>'

Finished in 0.1958 seconds (files took 1.8 seconds to load)
52 examples, 3 failures

Failed examples:

rspec ./spec/lib/twitter_bootstrap_rails/modal_helper_spec.rb:18 # ModalHelper returns a complete modal
rspec ./spec/lib/twitter_bootstrap_rails/modal_helper_spec.rb:38 # ModalHelper renders a cancel button
rspec ./spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb:108 # NavbarHelper menu_item should pass any other options through to the link_to method

```
