### PR TITLE
Extra separators removed from helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,11 +568,21 @@ Add flash helper `<%= bootstrap_flash %>` to your layout (built-in with layout g
 You do not need to use these breadcrumb gems since this gem provides the same functionality out of the box without the additional dependency.
 
 Add breadcrumbs helper `<%= render_breadcrumbs %>` to your layout.
-You can also specify a divider for it like this: `<%= render_breadcrumbs('>') %>` (default divider is `/`).
+You can also specify a separator for it like this: `<%= render_breadcrumbs separator: '>') %>` (default separater is `/`).
+Since [separator is a part of Bootstrap](http://getbootstrap.com/components/#breadcrumbs]) and they are automatically added this option is redundant.
+You can customize it via `css` through `:before` selector and `content`:
+```css
+.breadcrumb > li + li:before {
+    color: #ccc;
+    content: "/ ";
+    padding: 0 5px;
+}
+```
+Use `separater` option only if you would like to have it as HTML element. Do not forget to clear `content` at css.
 
 Full example:
 ```ruby
-render_breadcrumbs(" / ", { :class => '', :item_class => '', :divider_class => '', :active_class => 'active' })
+render_breadcrumbs :class => '', :item_class => '', :divider_class => '', :active_class => 'active'
 ```
 
 ```ruby

--- a/app/helpers/twitter_breadcrumbs_helper.rb
+++ b/app/helpers/twitter_breadcrumbs_helper.rb
@@ -1,7 +1,7 @@
 module TwitterBreadcrumbsHelper
-  def render_breadcrumbs(divider = '/', options={}, &block)
-    default_options = { :class => '', :item_class => '', :divider_class => '', :active_class => 'active' }.merge(options)
-    content = render :partial => 'twitter-bootstrap/breadcrumbs', :layout => false, :locals => { :divider => divider, options: options }
+  def render_breadcrumbs(options = {}, &block)
+    default_options = { :separator => '', :class => '', :item_class => '', :divider_class => '', :active_class => 'active' }.merge(options)
+    content = render :partial => 'twitter-bootstrap/breadcrumbs', :layout => false, :locals => { options: default_options }
     if block_given?
       capture(content, &block)
     else

--- a/app/views/twitter-bootstrap/_breadcrumbs.html.erb
+++ b/app/views/twitter-bootstrap/_breadcrumbs.html.erb
@@ -1,11 +1,9 @@
 <% if @breadcrumbs.present? %>
   <ul class="breadcrumb <%= options[:class] %>">
-    <% separator = divider.html_safe %>
+    <% separator = options[:separator].html_safe %>
+    <% partial = (separator.present?) ? 'crumb_with_sep' : 'crumb' -%>
     <% @breadcrumbs[0..-2].each do |crumb| %>
-      <li class="<%= options[:item_class] %>">
-        <%= link_to crumb[:name], crumb[:url], crumb[:options] %>
-        <span class="divider <%= options[:divider_class] %>"><%= separator %></span>
-      </li>
+      <%= render :partial => "twitter-bootstrap/#{ partial }", :locals => { :crumb => crumb, :separator => separator, :options => options } %>
     <% end %>
     <li class="<%= options[:active_class] %>">
       <%= @breadcrumbs.last[:name] %>

--- a/app/views/twitter-bootstrap/_crumb.html.erb
+++ b/app/views/twitter-bootstrap/_crumb.html.erb
@@ -1,0 +1,3 @@
+<li class="<%= options[:item_class] %>">
+  <%= link_to crumb[:name], crumb[:url], crumb[:options] %>
+</li>

--- a/app/views/twitter-bootstrap/_crumb_with_sep.html.erb
+++ b/app/views/twitter-bootstrap/_crumb_with_sep.html.erb
@@ -1,0 +1,4 @@
+<li class="<%= options[:item_class] %>">
+  <%= link_to crumb[:name], crumb[:url], crumb[:options] %>
+  <span class="divider <%= options[:divider_class] %>"><%= separator %></span>
+</li>


### PR DESCRIPTION
Based on [this tutorial](http://getbootstrap.com/components/#breadcrumbs) extra breadcrumb separators removed from helper.
`default_options` have never been used.
Optionally, we can specify it using `:separator` option.