### PR TITLE
Fix themed generators simple form error span templating issue

### DIFF
--- a/lib/generators/bootstrap/themed/templates/simple_form/_form.html.haml
+++ b/lib/generators/bootstrap/themed/templates/simple_form/_form.html.haml
@@ -1,7 +1,7 @@
 = simple_form_for @<%= resource_name %>, :html => { :class => 'form-horizontal' } do |f|
 <%- columns.each do |column| -%>
   = f.input :<%= column.name %>
-  = error_span(@<%= resource_name %>[:<%= column.name %>])
+  = f.error_span :<%= column.name %>
 <%- end -%>
 <%- if ::SimpleForm::FormBuilder.instance_methods.include?(:wrapped_button) -%>
   = f.button :wrapped, :cancel => <%= controller_routing_path %>_path


### PR DESCRIPTION
Bug for (components): Simple Form, HAML template, `error_span` helper
Bug: Themed generators are generating the following template:
```ruby
  = error_span(@example[:title])
```
What is missing to me:
i.. There were no form object
ii. By the above code it was actually passing the value of the attribute `:title`
But the error_span helper method expects:
i. form's object
ii. object's attribute name
References
https://github.com/seyhunak/twitter-bootstrap-rails/blob/master/app/helpers/form_errors_helper.rb#15

How to produce:
* 1. Use haml template 
* 2. Use default simple form 
* 3. Generate themed for any of your resources

My Fixes:
Just made a change that the template of simple form and haml part to ensure:
1. `error_span` is being called with form object
2.  `attribute` name is being passed to error_span helper

Now it seems all is working fine in my end. 
Thank you for such awesome gem. 