### PR TITLE
fix for options passed to menu_item

### DIFF
--- a/app/helpers/modal_helper.rb
+++ b/app/helpers/modal_helper.rb
@@ -7,7 +7,7 @@ module ModalHelper
   #modals have a header, a body, a footer for options.
   def modal_dialog(options = {}, &block)
     opts = default_options.merge(options)
-    content_tag :div, :id => options[:id], :class => "bootstrap-modal modal fade" do
+    content_tag :div, :class => "bootstrap-modal modal fade", :id => options[:id] do
       content_tag :div, :class => "modal-dialog #{opts['size']}" do
         content_tag :div, :class => "modal-content" do
           modal_header(options[:header], &block) +

--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -17,8 +17,11 @@ module NavbarHelper
     path = name || path if block_given?
     options = args.extract_options!
     content_tag :li, :class => is_active?(path, options) do
-      name, path = path, options if block_given?
-      link_to name, path, options, &block
+      if block_given?      
+	link_to path, options, &block
+	else
+	link_to name, path, options, &block
+	end 
     end
   end
 

--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -19,9 +19,9 @@ module NavbarHelper
     content_tag :li, :class => is_active?(path, options) do
       if block_given?      
 	link_to path, options, &block
-	else
+      else
 	link_to name, path, options, &block
-	end 
+      end 
     end
   end
 

--- a/spec/lib/twitter_bootstrap_rails/modal_helper_spec.rb
+++ b/spec/lib/twitter_bootstrap_rails/modal_helper_spec.rb
@@ -36,7 +36,7 @@ describe ModalHelper, :type => :helper do
   end
 
   it 'renders a cancel button' do
-    expect(modal_cancel_button("Cancel", :href => "#modal", :data => {:dismiss => 'modal'}).gsub(/\n/, "")).to eql MODAL_CANCEL_BUTTON.gsub(/\n/, "")
+    expect(modal_cancel_button("Cancel", :data => {:dismiss => 'modal'}, :href => "#modal").gsub(/\n/, "")).to eql MODAL_CANCEL_BUTTON.gsub(/\n/, "")
   end
 end
 

--- a/spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb
+++ b/spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb
@@ -107,7 +107,7 @@ describe NavbarHelper, :type => :helper do
     end
     it "should pass any other options through to the link_to method" do
       allow(self).to receive_message_chain("uri_state").and_return(:active)
-      expect(menu_item("Log out", "/users/sign_out", :class => "home_link", :method => :delete)).to eql('<li class="active"><a class="home_link" data-method="delete" href="/users/sign_out" rel="nofollow">Log out</a></li>')
+      expect(menu_item("Log out", "/users/sign_out", :class => "home_link", :method => :delete)).to eql('<li class="active"><a class="home_link" rel="nofollow" data-method="delete" href="/users/sign_out">Log out</a></li>')
     end
     it "should pass a block but no name if a block is present" do
       allow(self).to receive(:current_page?) { false }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,3 +15,7 @@ require 'abstract_controller'
 require 'action_controller'
 require 'mocha/api'
 require 'pry'
+
+RSpec.configure do |config|
+  config.include RSpecHtmlMatchers
+end


### PR DESCRIPTION
Hi,

I just fixed these bugs and clear the rspec results.
rspec ./spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb:100 # NavbarHelper menu_item should return a link within an li tag
rspec ./spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb:104 # NavbarHelper menu_item should return the link with class 'active' if on current page
rspec ./spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb:108 # NavbarHelper menu_item should pass any other options through to the link_to method
rspec ./spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb:112 # NavbarHelper menu_item should pass a block but no name if a block is present
rspec ./spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb:116 # NavbarHelper menu_item should work with just a block
rspec ./spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb:120 # NavbarHelper menu_item should return the link with class 'active' if on current page with a block

Thanks,
