### PR TITLE
Shut up please

### DIFF
--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -1,12 +1,12 @@
 module BootstrapFlashHelper
-  ALERT_TYPES = [:error, :info, :success, :warning]
+  ALERT_TYPES = [:error, :info, :success, :warning] unless const_defined?(:ALERT_TYPES)
 
   def bootstrap_flash
     flash_messages = []
     flash.each do |type, message|
       # Skip empty messages, e.g. for devise messages set to nothing in a locale file.
       next if message.blank?
-      
+
       type = :success if type == :notice
       type = :error   if type == :alert
       next unless ALERT_TYPES.include?(type)


### PR DESCRIPTION
Prevents:
/Users/joe/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/twitter-bootstrap-rails-4b8a511e6518/app/helpers/bootstrap_flash_helper.rb:2: warning: already initialized constant BootstrapFlashHelper::ALERT_TYPES
/Users/joe/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bundler/gems/twitter-bootstrap-rails-4b8a511e6518/app/helpers/bootstrap_flash_helper.rb:2: warning: previous definition of ALERT_TYPES was here