### PR TITLE
Add bootstrap flash options

### DIFF
--- a/CONTRIBUTERS.md
+++ b/CONTRIBUTERS.md
@@ -17,4 +17,5 @@
   <li>Christian Joudrey</li>
   <li>Todd Baur</li>
   <li>Leonid Shevtsov</li>
+  <li>Christophe Maximin</li>
 </ul>

--- a/README.md
+++ b/README.md
@@ -565,7 +565,9 @@ It also takes the :pull option to drag it to the left or right.
 
 ### Flash helper
 
-Add flash helper `<%= bootstrap_flash %>` to your layout (built-in with layout generator)
+Add flash helper `<%= bootstrap_flash %>` to your layout (built-in with layout generator).  
+You can pass the attributes you want to add to the main div returned: `<%= bootstrap_flash(class: "extra-class", id: "your-id") %>`
+
 
 ### Breadcrumbs Helpers
 

--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -13,10 +13,15 @@ module BootstrapFlashHelper
       type = :danger  if type == :error
       next unless ALERT_TYPES.include?(type)
 
+      tag_class = options.extract!(:class)[:class]
+      tag_options = {
+        class: "alert fade in alert-#{type} #{tag_class}"
+      }.merge(options)
+
+      close_button = content_tag(:button, raw("&times;"), class: "close", "data-dismiss" => "alert")
+
       Array(message).each do |msg|
-        text = content_tag(:div,
-                           content_tag(:button, raw("&times;"), :class => "close", "data-dismiss" => "alert") +
-                           msg.html_safe, :class => "alert fade in alert-#{type} #{options[:class]}")
+        text = content_tag(:div, close_button + msg.html_safe, tag_options)
         flash_messages << text if msg
       end
     end

--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -17,10 +17,10 @@ module NavbarHelper
     path = name || path if block_given?
     options = args.extract_options!
     content_tag :li, :class => is_active?(path, options) do
-      if block_given?      
-	link_to path, options, &block
+      if block_given?
+        link_to path, options, &block
       else
-	link_to name, path, options, &block
+        link_to name, path, options, &block
       end 
     end
   end

--- a/spec/lib/twitter_bootstrap_rails/bootstrap_flash_helper_spec.rb
+++ b/spec/lib/twitter_bootstrap_rails/bootstrap_flash_helper_spec.rb
@@ -1,0 +1,90 @@
+# encoding: utf-8
+require 'spec_helper'
+require 'action_view'
+require 'active_support'
+require_relative '../../../app/helpers/bootstrap_flash_helper'
+
+include ActionView::Helpers
+include ActionView::Context
+include BootstrapFlashHelper
+
+describe BootstrapFlashHelper, type: :helper do
+  before do
+    allow(self).to receive(:uri_state) { :inactive }
+    allow(self).to receive(:root_url) { '/' }
+  end
+
+  describe "bootstrap_flash" do
+    it "should not return anything without flashes" do
+      allow(self).to receive(:flash) { {} }
+
+      element = bootstrap_flash
+
+      expect(element).to eql("")
+    end
+
+    it "should work with a notice" do
+      allow(self).to receive(:flash) { {notice: "Hello"} }
+
+      element = bootstrap_flash
+
+      expect(element).to have_tag(:div,
+        text: "×Hello",
+        with: {class: "alert fade in alert-success"}) {
+
+        with_tag(:button,
+          text: "×",
+          with: {
+            class: "close",
+            "data-dismiss" => "alert"
+          }
+        )
+
+      }
+    end
+
+    it "should work with a notice and an extra class" do
+      allow(self).to receive(:flash) { {notice: "Hello"} }
+
+      element = bootstrap_flash(class: "extra-class")
+
+      expect(element).to have_tag(:div,
+        text: "×Hello",
+        with: {class: "alert fade in alert-success extra-class"}) {
+
+        with_tag(:button,
+          text: "×",
+          with: {
+            class: "close",
+            "data-dismiss" => "alert"
+          }
+        )
+
+      }
+    end
+
+    it "should work with a notice and an extra class and an extra attribute" do
+      allow(self).to receive(:flash) { {notice: "Hello"} }
+
+      element = bootstrap_flash(class: "extra-class", "data-no-transition-cache" => true)
+
+      expect(element).to have_tag(:div,
+        text: "×Hello",
+        with: {
+          class: "alert fade in alert-success extra-class",
+          "data-no-transition-cache" => true
+        }) {
+
+        with_tag(:button,
+          text: "×",
+          with: {
+            class: "close",
+            "data-dismiss" => "alert"
+          }
+        )
+
+      }
+    end
+  end
+
+end

--- a/spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb
+++ b/spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb
@@ -82,44 +82,94 @@ describe NavbarHelper, :type => :helper do
 
   describe "menu_group" do
     it "should return a ul with the class 'nav'" do
-      ele = menu_group do
+      element = menu_group do
         menu_item("Home", "/") + menu_item("Products", "/products")
       end
-      expect(ele).to eql '<ul class="nav navbar-nav "><li><a href="/">Home</a></li><li><a href="/products">Products</a></li></ul>'
+
+      expect(element).to have_tag(:ul, with: {class: "nav navbar-nav"}) {
+        with_tag(:li) {
+          with_tag(:a, text: "Home", with: {href: "/"})
+        }
+        with_tag(:li) {
+          with_tag(:a, text: "Products", with: {href: "/products"})
+        }
+      }
     end
 
-    it "should return a ul with class .navbar-left when passed the {:pull => :left} option" do
-      ele = menu_group(:pull => :left) do
+    it "should return a ul with class .navbar-left when passed the {pull: :left} option" do
+      element = menu_group(pull: :left) do
         menu_item("Home", "/")
       end
-      expect(ele).to eql('<ul class="nav navbar-nav navbar-left"><li><a href="/">Home</a></li></ul>')
+
+      expect(element).to have_tag(:ul, with: {class: "nav navbar-nav navbar-left"}) {
+        with_tag(:li) {
+          with_tag(:a, text: "Home", with: {href: "/"})
+        }
+      }
     end
   end
 
   describe "menu_item" do
     it "should return a link within an li tag" do
       allow(self).to receive(:current_page?) { false }
-      expect(menu_item("Home", "/")).to eql('<li><a href="/">Home</a></li>')
+
+      element = menu_item("Home", "/")
+      expect(element).to have_tag(:li) {
+        with_tag(:a, text: "Home", with: { href: "/" })
+      }
     end
+
     it "should return the link with class 'active' if on current page" do
       allow(self).to receive(:uri_state) { :active }
-      expect(menu_item("Home", "/")).to eql('<li class="active"><a href="/">Home</a></li>')
+
+      element = menu_item("Home", "/")
+      expect(element).to have_tag(:li, with: {class: "active"}) {
+        with_tag(:a, text: "Home", with: { href: "/" })
+      }
     end
+
     it "should pass any other options through to the link_to method" do
       allow(self).to receive_message_chain("uri_state").and_return(:active)
-      expect(menu_item("Log out", "/users/sign_out", :class => "home_link", :method => :delete)).to eql('<li class="active"><a class="home_link" rel="nofollow" data-method="delete" href="/users/sign_out">Log out</a></li>')
+
+      element = menu_item("Log out", "/users/sign_out", class: "home_link", method: :delete)
+      expect(element).to have_tag(:li, with: {class: "active"}) {
+        with_tag(:a, text: "Log out", with: {
+          href: "/users/sign_out",
+          class: "home_link",
+          rel: "nofollow",
+          "data-method" => "delete"
+        })
+      }
     end
+
     it "should pass a block but no name if a block is present" do
       allow(self).to receive(:current_page?) { false }
-      expect(menu_item("/"){content_tag("i", "", :class => "icon-home") + " Home"}).to eql('<li><a href="/"><i class="icon-home"></i> Home</a></li>')
+
+      element = menu_item("/"){ content_tag("i", "", :class => "icon-home") + " Home" }
+      expect(element).to have_tag(:li) {
+        with_tag(:i, with: { class: "icon-home"})
+        with_tag(:a, text: " Home", with: { href: "/"})
+      }
     end
+
     it "should work with just a block" do
       allow(self).to receive(:current_page?) { false }
-      expect(menu_item{ content_tag("i", "", :class => "icon-home") + " Home" }).to eql('<li><a href="#"><i class="icon-home"></i> Home</a></li>')
+
+      element = menu_item{ content_tag("i", "", :class => "icon-home") + " Home" }
+      expect(element).to have_tag(:li) {
+        with_tag(:i, with: { class: "icon-home"})
+        with_tag(:a, text: " Home", with: { href: "#"})
+      }
     end
+
     it "should return the link with class 'active' if on current page with a block" do
       allow(self).to receive(:uri_state) { :active }
-      expect(menu_item("/"){ content_tag("i", "", :class => "icon-home") + " Home" }).to eql('<li class="active"><a href="/"><i class="icon-home"></i> Home</a></li>')
+
+      element = menu_item("/"){ content_tag("i", "", :class => "icon-home") + " Home" }
+      expect(element).to have_tag(:li, with: {class: "active"}) {
+        with_tag(:i, with: { class: "icon-home"})
+        with_tag(:a, text: " Home", with: { href: "/"})
+      }
     end
   end
 


### PR DESCRIPTION
The first commit fixes the fix navbar helper specs, which failed on ruby 2.2.0 but worked on 2.0 and 1.9.3, because the attributes of content_tag ended up in a seemingly random order.
I replaced the raw ``eql()`` checks with ``have_tag()``s.

The second commit is the actual object of the pull request, and adds the ability to pass extra arguments to ``bootstrap_flash``, which previously only took a ``class``.
You can now do something like:
 ``<%= bootstrap_flash(class: "extra-class", id: "my-id", "data-no-transition-cache" => true) %>``