### PR TITLE
added role 'presentation' to navigation li tag

### DIFF
--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -16,7 +16,7 @@ module NavbarHelper
   def menu_item(name=nil, path="#", *args, &block)
     path = name || path if block_given?
     options = args.extract_options!
-    content_tag :li, :class => is_active?(path, options) do
+    content_tag :li, :role => "presentation", :class => is_active?(path, options) do
       if block_given?
         link_to path, options, &block
       else

--- a/spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb
+++ b/spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb
@@ -171,6 +171,13 @@ describe NavbarHelper, :type => :helper do
         with_tag(:a, text: " Home", with: { href: "/"})
       }
     end
+
+    it "should return a link with role 'presentation' attribute" do
+      allow(self).to receive(:current_page?) { false }
+
+      element = menu_item("Home", "/")
+      expect(element).to have_tag(:li, with: {role: "presentation"})
+    end
   end
 
   describe "drop_down" do


### PR DESCRIPTION
As the `<nav>` tag is used with `role="navigation"` the `<li>` tag should also have the corresponding attribute `role="presentation"` 

See: http://getbootstrap.com/components/#make-navs-used-as-navigation-accessible
