### PR TITLE
Not marking msg as html_safe by default.

### DIFF
--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -21,7 +21,7 @@ module BootstrapFlashHelper
       close_button = content_tag(:button, raw("&times;"), type: "button", class: "close", "data-dismiss" => "alert")
 
       Array(message).each do |msg|
-        text = content_tag(:div, close_button + msg.html_safe, tag_options)
+        text = content_tag(:div, close_button + msg, tag_options)
         flash_messages << text if msg
       end
     end

--- a/spec/lib/twitter_bootstrap_rails/bootstrap_flash_helper_spec.rb
+++ b/spec/lib/twitter_bootstrap_rails/bootstrap_flash_helper_spec.rb
@@ -85,6 +85,44 @@ describe BootstrapFlashHelper, type: :helper do
 
       }
     end
-  end
 
+    it "should escape javascript if not marked as safe by user" do
+      allow(self).to receive(:flash) { {notice: "<script>alert(1)</script>"} }
+
+      element = bootstrap_flash
+
+      expect(element).to have_tag(:div,
+                                  text: "×<script>alert(1)</script>",
+                                  with: {class: "alert fade in alert-success"}) {
+                           with_tag(:button,
+                                    text: "×",
+                                    with: {
+                                        class: "close",
+                                        "data-dismiss" => "alert"
+                                    }
+                           )
+                         }
+    end
+
+    it "should not escape a link if marked as safe by user" do
+      allow(self).to receive(:flash) { {notice: "<a href='example.com'>awesome link!</a>".html_safe} }
+
+      element = bootstrap_flash
+
+      expect(element).to have_tag(:div,
+                                  text: "×awesome link!",
+                                  with: {class: "alert fade in alert-success"}) { [
+                             with_tag(:button,
+                                      text: "×",
+                                      with: {
+                                          class: "close",
+                                          "data-dismiss" => "alert"
+                                      }
+                             ),
+                             with_tag(:a,
+                                      text: 'awesome link!')
+                         ]
+                         }
+    end
+  end
 end


### PR DESCRIPTION
This could be misused as attack vector for xss attacks.
Added two tests for checking the behavior in both cases: if user
escapes message or not.

See also #856