### PR TITLE
Fixed paths of fontawesome to use the ones declared in bootstrap_overrides.less

### DIFF
--- a/vendor/toolkit/fontawesome/path.less
+++ b/vendor/toolkit/fontawesome/path.less
@@ -3,12 +3,12 @@
 
 @font-face {
   font-family: 'FontAwesome';
-  src: url('@{fa-font-path}/fontawesome-webfont.eot?v=@{fa-version}');
-  src: url('@{fa-font-path}/fontawesome-webfont.eot?#iefix&v=@{fa-version}') format('embedded-opentype'),
-    url('@{fa-font-path}/fontawesome-webfont.woff?v=@{fa-version}') format('woff'),
-    url('@{fa-font-path}/fontawesome-webfont.ttf?v=@{fa-version}') format('truetype'),
-    url('@{fa-font-path}/fontawesome-webfont.svg?v=@{fa-version}#fontawesomeregular') format('svg');
-//  src: url('@{fa-font-path}/FontAwesome.otf') format('opentype'); // used when developing fonts
+  src: @fontAwesomeEotPath;
+  src: @fontAwesomeEotPath_iefix format('embedded-opentype'),
+  @fontAwesomeWoffPath format('woff'),
+  @fontAwesomeTtfPath format('truetype'),
+  @fontAwesomeSvgPath format('svg');
+  //  src: url('@{fa-font-path}/FontAwesome.otf') format('opentype'); // used when developing fonts
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Basically, I added bach the changes from https://github.com/seyhunak/twitter-bootstrap-rails/blob/8d2a6780bde0b5c7285a3198d051530526eb6ad4/vendor/toolkit/fontawesome/path.less which got lost again in an update of fontawesome. This also most probably fixes #866 and #833 in a more gem-compatible way.