### PR TITLE
Fix modal_dialog options

### DIFF
--- a/app/helpers/modal_helper.rb
+++ b/app/helpers/modal_helper.rb
@@ -6,7 +6,7 @@ module ModalHelper
 
   #modals have a header, a body, a footer for options.
   def modal_dialog(options = {}, &block)
-    options.merge!(default_options)
+    options = default_options.merge(options)
     content_tag :div, :class => "bootstrap-modal modal fade", :id => options[:id] do
       content_tag :div, :class => "modal-dialog #{options['size']}" do
         content_tag :div, :class => "modal-content" do


### PR DESCRIPTION
> If no block is specified, the value for entries with duplicate keys will be that of other_hash. 

[Class: Hash (Ruby 2.1.5) ](http://ruby-doc.org/core-2.1.5/Hash.html#method-i-merge)