### PR TITLE
breadcrumbs-on-rails compatibility for this gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,8 +571,11 @@ You can pass the attributes you want to add to the main div returned: `<%= boots
 
 ### Breadcrumbs Helpers
 
-*Notice* If your application is using [breadcrumbs-on-rails](https://github.com/weppos/breadcrumbs_on_rails) you will have a namespace collision with the add_breadcrumb method.
-You do not need to use these breadcrumb gems since this gem provides the same functionality out of the box without the additional dependency.
+*Notice* If your application is using [breadcrumbs-on-rails](https://github.com/weppos/breadcrumbs_on_rails) you will have a namespace collision with the add_breadcrumb method. For this reason if breadcrumbs-on-rails is detected in `Gemfile` gem methods will be accessible using `boostrap` prefix, i.e. `render_bootstrap_breadcrumbs` and `add_bootstrap_breadcrumb`
+
+Usually you do not need to use these breadcrumb gems since this gem provides the same functionality out of the box without the additional dependency.
+
+However if there are some `breadcrumbs-on-rails` features you need to keep you can still use them and use this gem with the prefixes explained above.
 
 Add breadcrumbs helper `<%= render_breadcrumbs %>` to your layout.
 You can also specify a divider for it like this: `<%= render_breadcrumbs('>') %>` (default divider is `/`).

--- a/app/helpers/twitter_breadcrumbs_helper.rb
+++ b/app/helpers/twitter_breadcrumbs_helper.rb
@@ -1,5 +1,5 @@
 module TwitterBreadcrumbsHelper
-  def render_breadcrumbs(divider = '/', options={}, &block)
+  def render_bootstrap_breadcrumbs(divider = '/', options={}, &block)
     default_options = { :class => '', :item_class => '', :divider_class => '', :active_class => 'active' }.merge(options)
     content = render :partial => 'twitter-bootstrap/breadcrumbs', :layout => false, :locals => { :divider => divider, options: options }
     if block_given?
@@ -8,4 +8,7 @@ module TwitterBreadcrumbsHelper
       content
     end
   end
+
+  # Add backward compatible alias unless BC on rails present
+  alias_method :render_breadcrumbs, :render_bootstrap_breadcrumbs unless defined?(::BreadcrumbsOnRails)
 end

--- a/app/views/twitter-bootstrap/_breadcrumbs.html.erb
+++ b/app/views/twitter-bootstrap/_breadcrumbs.html.erb
@@ -1,14 +1,14 @@
-<% if @breadcrumbs.present? %>
+<% if @__bs_breadcrumbs.present? %>
   <ul class="breadcrumb <%= options[:class] %>">
     <% separator = divider.html_safe if divider %>
-    <% @breadcrumbs[0..-2].each do |crumb| %>
+    <% @__bs_breadcrumbs[0..-2].each do |crumb| %>
       <li class="<%= options[:item_class] %>">
         <%= link_to crumb[:name], crumb[:url], crumb[:options] %>
         <span class="divider <%= options[:divider_class] %>"><%= separator if separator %></span>
       </li>
     <% end %>
     <li class="<%= options[:active_class] %>">
-      <%= @breadcrumbs.last[:name] %>
+      <%= @__bs_breadcrumbs.last[:name] %>
     </li>
   </ul>
 <% end %>

--- a/spec/lib/breadcrumbs_spec.rb
+++ b/spec/lib/breadcrumbs_spec.rb
@@ -46,29 +46,54 @@ describe Twitter::Bootstrap::Breadcrumbs do
     end
   end
 
-  before do
-    options = { :scope => [:breadcrumbs, 'test'] }
-    [:class_i18n, :instance_i18n, :show, :symbolized].each do |name|
-      I18n.expects(:t).with(name, options).returns(name.to_s)
+  describe 'Breadcrumbs generation' do
+
+    before do
+      options = { :scope => [:breadcrumbs, 'test'] }
+      [:class_i18n, :instance_i18n, :show, :symbolized].each do |name|
+        I18n.expects(:t).with(name, options).returns(name.to_s)
+      end
+
+      name = :base_i18n
+      options = { :scope => [:breadcrumbs, 'base_test'] }
+      I18n.expects(:t).with(name, options).returns(name)
+
+      @controller = TestController.new
+      @controller.process(:show)
     end
 
-    name = :base_i18n
-    options = { :scope => [:breadcrumbs, 'base_test'] }
-    I18n.expects(:t).with(name, options).returns(name)
+    it "have breadcrumbs" do
+      [:base, :base_i18n, :class, :class_i18n, :instance, :instance_i18n, :test_model, :symbolized].each do |name|
+        path = "/#{name}"
+        idx = @controller.breadcrumbs.index { |b| b[:name] == name.to_s && b[:url] == path }
+        expect(idx).to be, -> { name }
+      end
 
-    @controller = TestController.new
-    @controller.process(:show)
+      idx = @controller.breadcrumbs.index { |b| b[:name] == "show" && b[:url] == '' }
+      expect(idx).to be
+    end
   end
 
-  it "have breadcrumbs" do
-    [:base, :base_i18n, :class, :class_i18n, :instance, :instance_i18n, :test_model, :symbolized].each do |name|
-      path = "/#{name}"
-      idx = @controller.breadcrumbs.index { |b| b[:name] == name.to_s && b[:url] == path }
-      expect(idx).to be, -> { name }
+  describe 'BreadcrumbsOnRails compatibility' do
+    class SomeController < AbstractController::Base
+    end
+    let(:logger) { double('logger').as_null_object }
+    before { allow(::Rails).to receive(:logger).and_return(logger) }
+
+    context 'when BreadcrumbsOnRails is defined' do
+      before do
+        stub_const('BreadcrumbsOnRails', 1)
+        expect(defined?(::BreadcrumbsOnRails)).to be_truthy
+        expect(logger).to receive(:info).with /BreadcrumbsOnRails detected/
+        SomeController.send(:include, Twitter::Bootstrap::Breadcrumbs)
+      end
+
+      it 'does not define aliases' do
+        expect(SomeController).to respond_to :add_bootstrap_breadcrumb
+        expect(SomeController).not_to respond_to :add_breadcrumb
+      end
     end
 
-    idx = @controller.breadcrumbs.index { |b| b[:name] == "show" && b[:url] == '' }
-    expect(idx).to be
   end
 
 end

--- a/spec/lib/breadcrumbs_spec.rb
+++ b/spec/lib/breadcrumbs_spec.rb
@@ -18,7 +18,7 @@ describe Twitter::Bootstrap::Breadcrumbs do
     add_breadcrumb :base_i18n, '/base_i18n'
 
     def breadcrumbs
-      @breadcrumbs
+      @__bs_breadcrumbs
     end
   end
 


### PR DESCRIPTION
Using breadcrumbs-on-rails with this project is currently not possible. With this patch you will retain backward compatibility and also allow breadcrumbs-on-rails users to keep their code working.

This gem breadcrumb implementation is not fully compatibile and does not allow all features of breadcrumbs-on-rails so this patch might be very useful.

If breadcrumbs-on-rails is not present in Gemfile nothing will change for existing users.