### PR TITLE
refs #882, Breadcrumb without dividers

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ You do not need to use these breadcrumb gems since this gem provides the same fu
 
 Add breadcrumbs helper `<%= render_breadcrumbs %>` to your layout.
 You can also specify a divider for it like this: `<%= render_breadcrumbs('>') %>` (default divider is `/`).
+If you do not need dividers at all you can use `nil`: `<%= render_breadcrumbs(nil) %>`.
 
 Full example:
 ```ruby

--- a/app/views/twitter-bootstrap/_breadcrumbs.html.erb
+++ b/app/views/twitter-bootstrap/_breadcrumbs.html.erb
@@ -1,10 +1,10 @@
 <% if @breadcrumbs.present? %>
   <ul class="breadcrumb <%= options[:class] %>">
-    <% separator = divider.html_safe %>
+    <% separator = divider.html_safe if divider %>
     <% @breadcrumbs[0..-2].each do |crumb| %>
       <li class="<%= options[:item_class] %>">
         <%= link_to crumb[:name], crumb[:url], crumb[:options] %>
-        <span class="divider <%= options[:divider_class] %>"><%= separator %></span>
+        <span class="divider <%= options[:divider_class] %>"><%= separator if separator %></span>
       </li>
     <% end %>
     <li class="<%= options[:active_class] %>">


### PR DESCRIPTION
If you do not need dividers at all you can use `nil`: `<%= render_breadcrumbs(nil) %>`.