### PR TITLE
Allow custom class in nav_bar helper

### DIFF
--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -108,8 +108,9 @@ module NavbarHelper
     position = "static-#{options[:static].to_s}" if options[:static]
     position = "fixed-#{options[:fixed].to_s}" if options[:fixed]
     inverse = (options[:inverse].present? && options[:inverse] == true) ? true : false
+    classes = options[:class]
 
-    content_tag :nav, :class => nav_bar_css_class(position, inverse), :role => "navigation" do
+    content_tag :nav, :class => nav_bar_css_class(position, inverse, classes), :role => "navigation" do
       yield
     end
   end
@@ -144,10 +145,11 @@ module NavbarHelper
     end
   end
 
-  def nav_bar_css_class(position, inverse = false)
+  def nav_bar_css_class(position, inverse = false, classes=nil)
     css_class = ["navbar", "navbar-default"]
     css_class << "navbar-#{position}" if position.present?
     css_class << "navbar-inverse" if inverse
+    css_class << classes
     css_class.join(" ")
   end
 

--- a/spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb
+++ b/spec/lib/twitter_bootstrap_rails/navbar_helper_spec.rb
@@ -171,6 +171,11 @@ describe NavbarHelper, :type => :helper do
         with_tag(:a, text: " Home", with: { href: "/"})
       }
     end
+
+    it "should add custom class to navbar" do 
+      expect(nav_bar(:class => "custom-class"))
+        .to have_tag(:nav, with: { class: 'custom-class' } )
+    end
   end
 
   describe "drop_down" do


### PR DESCRIPTION
Allow custom class definition in nav_bar helper, for instance: 

``` Haml
= nav_bar class: "custom-class" do 
```

Would return

``` HTML
<nav class="navbar navbar-default custom-class">
```
