### PR TITLE
"Show" button added to index files

### DIFF
--- a/lib/generators/bootstrap/themed/templates/index.html.erb
+++ b/lib/generators/bootstrap/themed/templates/index.html.erb
@@ -23,7 +23,7 @@
         <td><%%=l <%= resource_name %>.created_at %></td>
         <td>
           <%%= link_to t('.show', :default => t("helpers.links.show")),
-                      show_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs' %>
+                      <%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs' %>
           <%%= link_to t('.edit', :default => t("helpers.links.edit")),
                       edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs' %>
           <%%= link_to t('.destroy', :default => t("helpers.links.destroy")),

--- a/lib/generators/bootstrap/themed/templates/index.html.erb
+++ b/lib/generators/bootstrap/themed/templates/index.html.erb
@@ -22,6 +22,8 @@
         <%- end -%>
         <td><%%=l <%= resource_name %>.created_at %></td>
         <td>
+          <%%= link_to t('.show', :default => t("helpers.links.show")),
+                      show_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs' %>
           <%%= link_to t('.edit', :default => t("helpers.links.edit")),
                       edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs' %>
           <%%= link_to t('.destroy', :default => t("helpers.links.destroy")),

--- a/lib/generators/bootstrap/themed/templates/index.html.haml
+++ b/lib/generators/bootstrap/themed/templates/index.html.haml
@@ -19,7 +19,7 @@
         <%- end -%>
         %td=l <%= resource_name %>.created_at
         %td
-          = link_to t('.show', :default => t("helpers.links.show")), show_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs'
+          = link_to t('.show', :default => t("helpers.links.show")), <%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs'
           = link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs'
           = link_to t('.destroy', :default => t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-xs btn-danger'
 

--- a/lib/generators/bootstrap/themed/templates/index.html.haml
+++ b/lib/generators/bootstrap/themed/templates/index.html.haml
@@ -19,6 +19,7 @@
         <%- end -%>
         %td=l <%= resource_name %>.created_at
         %td
+          = link_to t('.show', :default => t("helpers.links.show")), show_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs'
           = link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs'
           = link_to t('.destroy', :default => t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-xs btn-danger'
 

--- a/lib/generators/bootstrap/themed/templates/index.html.slim
+++ b/lib/generators/bootstrap/themed/templates/index.html.slim
@@ -19,7 +19,7 @@ table.table.table-striped
         <%- end -%>
         td=l <%= resource_name %>.created_at
         td
-          = link_to t('.show', :default => t("helpers.links.show")), show_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs'
+          = link_to t('.show', :default => t("helpers.links.show")), <%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs'
           '
           = link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs'
           '

--- a/lib/generators/bootstrap/themed/templates/index.html.slim
+++ b/lib/generators/bootstrap/themed/templates/index.html.slim
@@ -19,6 +19,8 @@ table.table.table-striped
         <%- end -%>
         td=l <%= resource_name %>.created_at
         td
+          = link_to t('.show', :default => t("helpers.links.show")), show_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs'
+          '
           = link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs'
           '
           = link_to t('.destroy', :default => t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-xs btn-danger'


### PR DESCRIPTION
Hi,
In normal rails scaffolding we have three action buttons on index page, which are show, edit, destroy. 

In twitter bootstrap gem we only had edit and destroy, so whenever I themed any of my resource, the show button disappears because in generators show button is not added.

I have added just 3 lines for that specific show button, so that the scaffold resource can be themed as per rails scaffolding standard buttons.

I hope this will help the developers.

Kind regards,
Hafiz Abdur Rehman
