### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ You can pass the attributes you want to add to the main div returned: `<%= boots
 
 ### Breadcrumbs Helpers
 
-*Notice* If your application is using [breadcrumbs-on-rails](https://github.com/weppos/breadcrumbs_on_rails) you will have a namespace collision with the add_breadcrumb method. For this reason if breadcrumbs-on-rails is detected in `Gemfile` gem methods will be accessible using `boostrap` prefix, i.e. `render_bootstrap_breadcrumbs` and `add_bootstrap_breadcrumb`
+*Notice* If your application is using [breadcrumbs-on-rails](https://github.com/weppos/breadcrumbs_on_rails) you will have a namespace collision with the add_breadcrumb method. For this reason if breadcrumbs-on-rails is detected in `Gemfile` gem methods will be accessible using `bootstrap` prefix, i.e. `render_bootstrap_breadcrumbs` and `add_bootstrap_breadcrumb`
 
 Usually you do not need to use these breadcrumb gems since this gem provides the same functionality out of the box without the additional dependency.
 

--- a/app/helpers/modal_helper.rb
+++ b/app/helpers/modal_helper.rb
@@ -34,8 +34,7 @@ module ModalHelper
   end
 
   def close_button(dismiss)
-    #It doesn't seem to like content_tag, so we do this instead.
-    raw("<button class=\"close\" data-dismiss=\"#{dismiss}\" aria-hidden=\"true\">&times;</button>")
+    content_tag :button, '&times;'.html_safe, { :class => 'close', "data-dismiss" => dismiss, "aria-hidden" => true }
   end
 
   def modal_toggle(content_or_options = nil, options, &block)


### PR DESCRIPTION
`boostrap` → `bootstrap`