### PR TITLE
Fix namespace issue for modularized model theme generation. Fix error_span on theme form templates

### DIFF
--- a/lib/generators/bootstrap/themed/templates/_form.html.erb
+++ b/lib/generators/bootstrap/themed/templates/_form.html.erb
@@ -1,13 +1,13 @@
-<%%= form_for @<%= resource_name %>, :html => { :class => "form-horizontal <%= resource_name %>" } do |f| %>
+<%%= form_for @<%= instance_resource_name %>, :html => { :class => "form-horizontal <%= instance_resource_name %>" } do |f| %>
 
-  <%% if @<%= resource_name %>.errors.any? %>
+  <%% if @<%= instance_resource_name %>.errors.any? %>
     <div id="error_expl" class="panel panel-danger">
       <div class="panel-heading">
-        <h3 class="panel-title"><%%= pluralize(@<%= resource_name %>.errors.count, "error") %> prohibited this <%= resource_name %> from being saved:</h3>
+        <h3 class="panel-title"><%%= pluralize(@<%= instance_resource_name %>.errors.count, "error") %> prohibited this <%= resource_name %> from being saved:</h3>
       </div>
       <div class="panel-body">
         <ul>
-        <%% @<%= resource_name %>.errors.full_messages.each do |msg| %>
+        <%% @<%= instance_resource_name %>.errors.full_messages.each do |msg| %>
           <li><%%= msg %></li>
         <%% end %>
         </ul>

--- a/lib/generators/bootstrap/themed/templates/_form.html.haml
+++ b/lib/generators/bootstrap/themed/templates/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @<%= resource_name %>, html: { class: "form form-horizontal <%= resource_name %>" } do |f|
+= form_for @<%= instance_resource_name %>, html: { class: "form form-horizontal <%= instance_resource_name %>" } do |f|
   <%- columns.each do |column| -%>
   .form-group
     = f.label :<%= column.name %>, class: 'control-label col-lg-2'

--- a/lib/generators/bootstrap/themed/templates/_form.html.slim
+++ b/lib/generators/bootstrap/themed/templates/_form.html.slim
@@ -1,4 +1,4 @@
-= form_for @<%= resource_name %>, html: { class: "form form-horizontal <%= resource_name %>" } do |f|
+= form_for @<%= instance_resource_name %>, html: { class: "form form-horizontal <%= instance_resource_name %>" } do |f|
   <%- columns.each do |column| -%>
   .form-group
     = f.label :<%= column.name %>, :class => 'control-label col-lg-2'

--- a/lib/generators/bootstrap/themed/templates/index.html.erb
+++ b/lib/generators/bootstrap/themed/templates/index.html.erb
@@ -14,20 +14,20 @@
     </tr>
   </thead>
   <tbody>
-    <%% @<%= plural_resource_name %>.each do |<%= resource_name %>| %>
+    <%% @<%= plural_instance_resource_name %>.each do |<%= instance_resource_name %>| %>
       <tr>
-        <td><%%= link_to <%= resource_name %>.id, <%= singular_controller_routing_path %>_path(<%= resource_name %>) %></td>
+        <td><%%= link_to <%= instance_resource_name %>.id, <%= singular_controller_routing_path %>_path(<%= instance_resource_name %>) %></td>
         <%- columns.each do |column| -%>
-        <td><%%= <%= resource_name %>.<%= column.name %> %></td>
+        <td><%%= <%= instance_resource_name %>.<%= column.name %> %></td>
         <%- end -%>
-        <td><%%=l <%= resource_name %>.created_at %></td>
+        <td><%%=l <%= instance_resource_name %>.created_at %></td>
         <td>
           <%%= link_to t('.show', :default => t("helpers.links.show")),
-                      <%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs' %>
+                      <%= singular_controller_routing_path %>_path(<%= instance_resource_name %>), :class => 'btn btn-default btn-xs' %>
           <%%= link_to t('.edit', :default => t("helpers.links.edit")),
-                      edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs' %>
+                      edit_<%= singular_controller_routing_path %>_path(<%= instance_resource_name %>), :class => 'btn btn-default btn-xs' %>
           <%%= link_to t('.destroy', :default => t("helpers.links.destroy")),
-                      <%= singular_controller_routing_path %>_path(<%= resource_name %>),
+                      <%= singular_controller_routing_path %>_path(<%= instance_resource_name %>),
                       :method => :delete,
                       :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
                       :class => 'btn btn-xs btn-danger' %>

--- a/lib/generators/bootstrap/themed/templates/index.html.haml
+++ b/lib/generators/bootstrap/themed/templates/index.html.haml
@@ -11,16 +11,16 @@
       %th= model_class.human_attribute_name(:created_at)
       %th=t '.actions', :default => t("helpers.actions")
   %tbody
-    - @<%= plural_resource_name %>.each do |<%= resource_name %>|
+    - @<%= plural_instance_resource_name %>.each do |<%= instance_resource_name %>|
       %tr
-        %td= link_to <%= resource_name %>.id, <%= singular_controller_routing_path %>_path(<%= resource_name %>)
+        %td= link_to <%= instance_resource_name %>.id, <%= singular_controller_routing_path %>_path(<%= instance_resource_name %>)
         <%- columns.each do |column| -%>
-        %td= <%= resource_name %>.<%= column.name %>
+        %td= <%= instance_resource_name %>.<%= column.name %>
         <%- end -%>
-        %td=l <%= resource_name %>.created_at
+        %td=l <%= instance_resource_name %>.created_at
         %td
-          = link_to t('.show', :default => t("helpers.links.show")), <%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs'
-          = link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs'
-          = link_to t('.destroy', :default => t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-xs btn-danger'
+          = link_to t('.show', :default => t("helpers.links.show")), <%= singular_controller_routing_path %>_path(<%= instance_resource_name %>), :class => 'btn btn-default btn-xs'
+          = link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(<%= instance_resource_name %>), :class => 'btn btn-default btn-xs'
+          = link_to t('.destroy', :default => t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(<%= instance_resource_name %>), :method => :delete, :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-xs btn-danger'
 
 = link_to t('.new', :default => t("helpers.links.new")), new_<%= singular_controller_routing_path %>_path, :class => 'btn btn-primary'

--- a/lib/generators/bootstrap/themed/templates/index.html.slim
+++ b/lib/generators/bootstrap/themed/templates/index.html.slim
@@ -11,18 +11,18 @@ table.table.table-striped
       th= model_class.human_attribute_name(:created_at)
       th=t '.actions', :default => t("helpers.actions")
   tbody
-    - @<%= plural_resource_name %>.each do |<%= resource_name %>|
+    - @<%= plural_instance_resource_name %>.each do |<%= instance_resource_name %>|
       tr
-        td= link_to <%= resource_name %>.id, <%= singular_controller_routing_path %>_path(<%= resource_name %>)
+        td= link_to <%= instance_resource_name %>.id, <%= singular_controller_routing_path %>_path(<%= instance_resource_name %>)
         <%- columns.each do |column| -%>
-        td= <%= resource_name %>.<%= column.name %>
+        td= <%= instance_resource_name %>.<%= column.name %>
         <%- end -%>
-        td=l <%= resource_name %>.created_at
+        td=l <%= instance_resource_name %>.created_at
         td
-          = link_to t('.show', :default => t("helpers.links.show")), <%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs'
+          = link_to t('.show', :default => t("helpers.links.show")), <%= singular_controller_routing_path %>_path(<%= instance_resource_name %>), :class => 'btn btn-default btn-xs'
           '
-          = link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(<%= resource_name %>), :class => 'btn btn-default btn-xs'
+          = link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(<%= instance_resource_name %>), :class => 'btn btn-default btn-xs'
           '
-          = link_to t('.destroy', :default => t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(<%= resource_name %>), :method => :delete, :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-xs btn-danger'
+          = link_to t('.destroy', :default => t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(<%= instance_resource_name %>), :method => :delete, :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-xs btn-danger'
 
 = link_to t('.new', :default => t("helpers.links.new")), new_<%= singular_controller_routing_path %>_path, :class => 'btn btn-primary'

--- a/lib/generators/bootstrap/themed/templates/show.html.erb
+++ b/lib/generators/bootstrap/themed/templates/show.html.erb
@@ -6,16 +6,16 @@
 <dl class="dl-horizontal">
 <%- columns.each do |column| -%>
   <dt><strong><%%= model_class.human_attribute_name(:<%= column.name %>) %>:</strong></dt>
-  <dd><%%= @<%= resource_name %>.<%= column.name %> %></dd>
+  <dd><%%= @<%= instance_resource_name %>.<%= column.name %> %></dd>
 <%- end -%>
 </dl>
 
 <%%= link_to t('.back', :default => t("helpers.links.back")),
               <%= controller_routing_path %>_path, :class => 'btn btn-default'  %>
 <%%= link_to t('.edit', :default => t("helpers.links.edit")),
-              edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), :class => 'btn btn-default' %>
+              edit_<%= singular_controller_routing_path %>_path(@<%= instance_resource_name %>), :class => 'btn btn-default' %>
 <%%= link_to t('.destroy', :default => t("helpers.links.destroy")),
-              <%= singular_controller_routing_path %>_path(@<%= resource_name %>),
+              <%= singular_controller_routing_path %>_path(@<%= instance_resource_name %>),
               :method => 'delete',
               :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
               :class => 'btn btn-danger' %>

--- a/lib/generators/bootstrap/themed/templates/show.html.haml
+++ b/lib/generators/bootstrap/themed/templates/show.html.haml
@@ -6,10 +6,10 @@
 %p
   %strong= model_class.human_attribute_name(:<%= column.name %>) + ':'
   %br
-  = @<%= resource_name %>.<%= column.name %>
+  = @<%= instance_resource_name %>.<%= column.name %>
 <%- end -%>
 
 
 = link_to t('.back', :default => t("helpers.links.back")), <%= controller_routing_path %>_path, :class => 'btn btn-default'
-= link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), :class => 'btn btn-default'
-= link_to t('.destroy', :default => t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :method => "delete", :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-danger'
+= link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(@<%= instance_resource_name %>), :class => 'btn btn-default'
+= link_to t('.destroy', :default => t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(@<%= instance_resource_name %>), :method => "delete", :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-danger'

--- a/lib/generators/bootstrap/themed/templates/show.html.slim
+++ b/lib/generators/bootstrap/themed/templates/show.html.slim
@@ -6,11 +6,11 @@
 p
   strong= model_class.human_attribute_name(:<%= column.name %>) + ':'
   br
-  = @<%= resource_name %>.<%= column.name %>
+  = @<%= instance_resource_name %>.<%= column.name %>
 <%- end -%>
 
 = link_to t('.back', :default => t("helpers.links.back")), <%= controller_routing_path %>_path, :class => 'btn btn-default'
 '
-= link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(@<%= resource_name %>), :class => 'btn btn-default'
+= link_to t('.edit', :default => t("helpers.links.edit")), edit_<%= singular_controller_routing_path %>_path(@<%= instance_resource_name %>), :class => 'btn btn-default'
 '
-= link_to t('.destroy', :default => t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(@<%= resource_name %>), :method => "delete", :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-danger'
+= link_to t('.destroy', :default => t("helpers.links.destroy")), <%= singular_controller_routing_path %>_path(@<%= instance_resource_name %>), :method => "delete", :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-danger'

--- a/lib/generators/bootstrap/themed/templates/simple_form/_form.html.erb
+++ b/lib/generators/bootstrap/themed/templates/simple_form/_form.html.erb
@@ -1,4 +1,4 @@
-<%%= simple_form_for @<%= resource_name %>, :html => { :class => 'form-horizontal' } do |f| %>
+<%%= simple_form_for @<%= instance_resource_name %>, :html => { :class => 'form-horizontal' } do |f| %>
   <%- columns.each do |column| -%>
   <%%= f.input :<%= column.name %> %>
   <%%= error_span(@<%= resource_name %>[:<%= column.name %>]) %>

--- a/lib/generators/bootstrap/themed/templates/simple_form/_form.html.erb
+++ b/lib/generators/bootstrap/themed/templates/simple_form/_form.html.erb
@@ -1,7 +1,7 @@
 <%%= simple_form_for @<%= instance_resource_name %>, :html => { :class => 'form-horizontal' } do |f| %>
   <%- columns.each do |column| -%>
   <%%= f.input :<%= column.name %> %>
-  <%%= error_span(@<%= resource_name %>[:<%= column.name %>]) %>
+  <%%= f.error_span(:<%= column.name %>) %>
   <%- end -%>
   <%- if ::SimpleForm::FormBuilder.instance_methods.include?(:wrapped_button) -%>
   <%%= f.button :wrapped, :cancel => <%= controller_routing_path %>_path %>

--- a/lib/generators/bootstrap/themed/templates/simple_form/_form.html.haml
+++ b/lib/generators/bootstrap/themed/templates/simple_form/_form.html.haml
@@ -1,4 +1,4 @@
-= simple_form_for @<%= resource_name %>, :html => { :class => 'form-horizontal' } do |f|
+= simple_form_for @<%= instance_resource_name %>, :html => { :class => 'form-horizontal' } do |f|
 <%- columns.each do |column| -%>
   = f.input :<%= column.name %>
   = f.error_span :<%= column.name %>

--- a/lib/generators/bootstrap/themed/templates/simple_form/_form.html.slim
+++ b/lib/generators/bootstrap/themed/templates/simple_form/_form.html.slim
@@ -1,4 +1,4 @@
-= simple_form_for @<%= resource_name %>, :html => { :class => "form-horizontal" } do |f|
+= simple_form_for @<%= instance_resource_name %>, :html => { :class => "form-horizontal" } do |f|
 <%- columns.each do |column| -%>
   = f.input :<%= column.name %>
   = error_span(@<%= resource_name %>[:<%= column.name %>])

--- a/lib/generators/bootstrap/themed/templates/simple_form/_form.html.slim
+++ b/lib/generators/bootstrap/themed/templates/simple_form/_form.html.slim
@@ -1,7 +1,7 @@
 = simple_form_for @<%= instance_resource_name %>, :html => { :class => "form-horizontal" } do |f|
 <%- columns.each do |column| -%>
   = f.input :<%= column.name %>
-  = error_span(@<%= resource_name %>[:<%= column.name %>])
+  = f.error_span(:<%= column.name %>)
 <%- end -%>
 <%- if ::SimpleForm::FormBuilder.instance_methods.include?(:wrapped_button) -%>
   = f.button :wrapped, :cancel => <%= controller_routing_path %>_path

--- a/lib/generators/bootstrap/themed/themed_generator.rb
+++ b/lib/generators/bootstrap/themed/themed_generator.rb
@@ -27,7 +27,7 @@ module Bootstrap
         @base_name, @controller_class_path, @controller_file_path, @controller_class_nesting, @controller_class_nesting_depth = extract_modules(controller_path)
         @controller_routing_path = @controller_file_path.gsub(/\//, '_')
         @model_name = @controller_class_nesting + "::#{@base_name.singularize.camelize}" unless @model_name
-        @model_name = @model_name.camelize
+        @model_name = @model_name.camelize.gsub(/^::/, '')
       end
 
       def controller_routing_path
@@ -47,11 +47,19 @@ module Bootstrap
       end
 
       def resource_name
-        @model_name.demodulize.underscore
+        @model_name.underscore
+      end
+
+      def instance_resource_name
+        @model_name.gsub('::', '_').underscore
       end
 
       def plural_resource_name
         resource_name.pluralize
+      end
+
+      def plural_instance_resource_name
+        instance_resource_name.pluralize
       end
 
       def columns


### PR DESCRIPTION
PR fixes issues when generating themes against a nested model.

For example: rails g bootstrap:themed Admin::Users

``` ruby
Rails.application.routes.draw do
  root to: 'page#index'
  namespace :admin do
    root to: 'admin#index'
    devise_for :users, class_name: "Admin::User", module: :devise
    resources :users
  end
end
```

PR also includes commit to fix error in form error_span
