### PR TITLE
Fix Rails 5 deprecation warnings

### DIFF
--- a/lib/twitter/bootstrap/rails/breadcrumbs.rb
+++ b/lib/twitter/bootstrap/rails/breadcrumbs.rb
@@ -24,7 +24,7 @@ module Twitter
       module ClassMethods
         def add_bootstrap_breadcrumb(name, url = '', options = {})
           options.merge! :klass => self.name
-          before_filter options do |controller|
+          before_action options do |controller|
             controller.send :add_bootstrap_breadcrumb, name, url, options
           end
         end


### PR DESCRIPTION
Use before_action rather than before_filter. 

More: http://edgeguides.rubyonrails.org/5_0_release_notes.html#action-pack-deprecations
