### PR TITLE
Bump less-rails to remove deprecation warnings, fixes #925

### DIFF
--- a/twitter-bootstrap-rails.gemspec
+++ b/twitter-bootstrap-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'railties', '~> 5.0', '>= 5.0.1'
   s.add_dependency 'actionpack', '~> 5.0', '>= 5.0.1'
-  s.add_dependency 'less-rails', '~> 2.8', '>= 2.8.0'
+  s.add_dependency 'less-rails', '~> 3.0', '>= 3.0.0'
 
   s.add_runtime_dependency 'execjs', '~> 2.7'
   s.add_development_dependency 'rails', '~> 5.0', '>= 5.0.1'


### PR DESCRIPTION
The warning is:

```
DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
Please register a mime type using `register_mime_type` then
use `register_compressor` or `register_transformer`.
```

This problem is really a less-rails error, and is documented in this
issue of that repo:

https://github.com/metaskills/less-rails/issues/122

It was fixed with this PR, merged Oct 2017:

https://github.com/metaskills/less-rails/pull/137

Bumping our less-rails dependency to 3.0.0 will give us the updates in
that PR.

Version 3.0.0 is the next version after 2.8.0, so there are very few
other changes to worry about.  You can view all of the less-rails code
changes between 2.8.0 and 3.0.0 here:

https://github.com/metaskills/less-rails/compare/05186eb...7bb14e5

They are almost all test and/or README changes. So this update should be
low risk.